### PR TITLE
feat(Tracing): use NoopTracer by default

### DIFF
--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Tracing;
 
+use OpenTelemetry\API\Trace\NoopTracer;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
@@ -36,7 +37,11 @@ final class Tracing
 
     public static function getTracer(): TracerInterface
     {
-        return new Tracer(self::getProvider()->getTracer(self::NAME));
+        if(null === $tracer = self::getProvider()?->getTracer(self::NAME)) {
+            $tracer = NoopTracer::getInstance();
+        }
+
+        return new Tracer($tracer);
     }
 
     public static function setProvider(TracerProviderInterface $tracerProvider): void
@@ -44,12 +49,8 @@ final class Tracing
         self::$tracerProvider = $tracerProvider;
     }
 
-    private static function getProvider(): TracerProviderInterface
+    private static function getProvider(): ?TracerProviderInterface
     {
-        if (!self::$tracerProvider) {
-            throw new \RuntimeException('No trace provider was set.');
-        }
-
         return self::$tracerProvider;
     }
 }

--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -20,6 +20,7 @@ final class Tracing
     public const NAME = 'io.opentelemetry.contrib.php';
 
     private static ?TracerProviderInterface $tracerProvider = null;
+    private static ?TracerInterface $tracer = null;
 
     /**
      * @param non-empty-string     $operation
@@ -37,11 +38,15 @@ final class Tracing
 
     public static function getTracer(): TracerInterface
     {
-        if(null === $tracer = self::getProvider()?->getTracer(self::NAME)) {
-            $tracer = NoopTracer::getInstance();
+        if (null === self::$tracer) {
+            if(null === $tracer = self::getProvider()?->getTracer(self::NAME)) {
+                $tracer = NoopTracer::getInstance();
+            }
+
+            self::$tracer = new Tracer($tracer);
         }
 
-        return new Tracer($tracer);
+        return self::$tracer;
     }
 
     public static function setProvider(TracerProviderInterface $tracerProvider): void


### PR DESCRIPTION
Currently if we don't provide a tracer provider to the `Tracing` class when we try to trace something we got an exception.
This forces us to configure the `Tracing` class in our unit tests to avoid this exception.

This PR propose to use the `NoopTracer` provided by open telemetry instead.
In addition I also propose to always use the same tracer instance instead of creating a new one every time, it's already what open telemetry does as we can see with the `NoopTracer::getInstance()`.