### PR TITLE
Fix the priority of the serializer's normalizers and decorate the one from API Platform

### DIFF
--- a/src/DependencyInjection/config/tracing/tracing.php
+++ b/src/DependencyInjection/config/tracing/tracing.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Resources;
 
+use ApiPlatform\Core\Problem\Serializer\ErrorNormalizer as ApiPlatformErrorNormalizer;
 use Instrumentation\Tracing\Exporter\ResetSpanExporter;
 use Instrumentation\Tracing\Factory\ExporterFactory;
 use Instrumentation\Tracing\Factory\SamplerFactory;
@@ -124,8 +125,21 @@ return static function (ContainerConfigurator $container) {
 
     if (class_exists(Serializer::class)) {
         $container->services()
-            ->set(ErrorNormalizer::class)
+            ->set('worldia-instrumentation.serializer.normalizer.problem')
+            ->class(ErrorNormalizer::class)
             ->decorate('serializer.normalizer.problem')
+            ->args([
+                service('.inner'),
+                param('kernel.debug'),
+                service(TraceUrlGeneratorInterface::class)->nullOnInvalid(),
+            ]);
+    }
+
+    if (class_exists(ApiPlatformErrorNormalizer::class)) {
+        $container->services()
+            ->set('worldia-instrumentation.problem.normalizer.error')
+            ->class(ErrorNormalizer::class)
+            ->decorate('api_platform.problem.normalizer.error')
             ->args([
                 service('.inner'),
                 param('kernel.debug'),

--- a/src/DependencyInjection/config/tracing/tracing.php
+++ b/src/DependencyInjection/config/tracing/tracing.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Instrumentation\Resources;
 
-use ApiPlatform\Core\Problem\Serializer\ErrorNormalizer as ApiPlatformErrorNormalizer;
 use Instrumentation\Tracing\Exporter\ResetSpanExporter;
 use Instrumentation\Tracing\Factory\ExporterFactory;
 use Instrumentation\Tracing\Factory\SamplerFactory;
@@ -125,21 +124,8 @@ return static function (ContainerConfigurator $container) {
 
     if (class_exists(Serializer::class)) {
         $container->services()
-            ->set('worldia-instrumentation.serializer.normalizer.problem')
-            ->class(ErrorNormalizer::class)
+            ->set(ErrorNormalizer::class)
             ->decorate('serializer.normalizer.problem')
-            ->args([
-                service('.inner'),
-                param('kernel.debug'),
-                service(TraceUrlGeneratorInterface::class)->nullOnInvalid(),
-            ]);
-    }
-
-    if (class_exists(ApiPlatformErrorNormalizer::class)) {
-        $container->services()
-            ->set('worldia-instrumentation.problem.normalizer.error')
-            ->class(ErrorNormalizer::class)
-            ->decorate('api_platform.problem.normalizer.error')
             ->args([
                 service('.inner'),
                 param('kernel.debug'),

--- a/src/DependencyInjection/config/tracing/tracing.php
+++ b/src/DependencyInjection/config/tracing/tracing.php
@@ -130,9 +130,7 @@ return static function (ContainerConfigurator $container) {
                 service('.inner'),
                 param('kernel.debug'),
                 service(TraceUrlGeneratorInterface::class)->nullOnInvalid(),
-            ])
-            ->tag('serializer.normalizer')
-            ->autoconfigure();
+            ]);
     }
 
     if (class_exists(TwigBundle::class)) {


### PR DESCRIPTION
As explained in the commits the current decoration was overriding the tag used to define a normalizer and therefore changed the priority of those normalizers which would introduce a breaking change for projects with their own problem normalizer.

In addition I also added the decoration of the error normalizer provided by API Platform since it takes the priority over the one from Symfony.