### PR TITLE
fix adding TraceContextStamp to messages by preventing failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
             "Instrumentation\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "spec\\Instrumentation\\": "spec/"
+        }
+    },
     "config": {
         "optimize-autoloader": true,
         "preferred-install": {

--- a/spec/Tracing/Propagation/EventSubscriber/MessengerEventSubscriberSpec.php
+++ b/spec/Tracing/Propagation/EventSubscriber/MessengerEventSubscriberSpec.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation\Tracing\Propagation\EventSubscriber;
+
+use Instrumentation\Tracing\Propagation\Exception\ContextPropagationException;
+use Instrumentation\Tracing\Propagation\Messenger\TraceContextStamp;
+use OpenTelemetry\API\Trace\NonRecordingSpan;
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanContextKey;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ScopeInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Webmozart\Assert\Assert;
+
+class MessengerEventSubscriberSpec extends ObjectBehavior
+{
+    private NonRecordingSpan $span;
+    private ScopeInterface $scope;
+
+    public function it_subsribes_to_events(): void
+    {
+        self::getSubscribedEvents()->shouldBe([
+            SendMessageToTransportsEvent::class => [['onSend', 1000]],
+            WorkerMessageReceivedEvent::class => [['onConsume', 1001]],
+        ]);
+    }
+
+    public function let(): void
+    {
+        // Needed to be able to undo the changes to the store when propagating a context trace
+        // Otherwise we have conflict with other tests because of the global scope
+        Context::storage()->fork(1);
+        Context::storage()->switch(1);
+        $this->activateSpan();
+    }
+
+    public function letGo(): void
+    {
+        $this->closeSpan();
+        Context::storage()->destroy(1);
+        Context::storage()->switch(1);
+    }
+
+    private function activateSpan(): void
+    {
+        $this->span = new NonRecordingSpan(SpanContext::create(
+            '728217a6fe6cda718f10969d62f5bbc1',
+            '6124380ad2dddeba',
+        ));
+        $this->scope = $this->span->activate();
+    }
+
+    private function closeSpan(): void
+    {
+        $this->scope->detach();
+        $this->span->end();
+    }
+
+    public function it_fails_when_message_is_sent_without_being_able_to_propagate_trace_context(): void
+    {
+        $this->closeSpan();
+        $event = new SendMessageToTransportsEvent($this->createEnveloppeWithoutTraceContextStamp());
+
+        $this->shouldThrow(ContextPropagationException::becauseNoParentTrace())->duringOnSend($event);
+    }
+
+    private function createEnveloppeWithoutTraceContextStamp(): Envelope
+    {
+        return new Envelope(new \stdClass());
+    }
+
+    public function it_adds_trace_context_stamp_when_message_is_sent(): void
+    {
+        $event = new SendMessageToTransportsEvent($this->createEnveloppeWithoutTraceContextStamp());
+
+        $this->onSend($event);
+
+        Assert::notNull(
+            $event->getEnvelope()->last(TraceContextStamp::class),
+            'The TraceContextStamp was not added to the envelope.',
+        );
+    }
+
+    public function it_does_nothing_when_receiving_message_without_trace_context_stamp(): void
+    {
+        $this->closeSpan();
+        $event = new WorkerMessageReceivedEvent(
+            $this->createEnveloppeWithoutTraceContextStamp(),
+            'receiverName',
+        );
+        $previousContext = Context::getCurrent();
+
+        $this->onConsume($event);
+
+        Assert::same(Context::getCurrent(), $previousContext);
+    }
+
+    public function it_propagates_trace_context_when_receiving_message_with_trace_context_stamp(): void
+    {
+        $event = new WorkerMessageReceivedEvent(
+            $this->createEnveloppeWithTraceContextStamp(),
+            'receiverName',
+        );
+        $this->closeSpan();
+        $previousContext = Context::getCurrent();
+
+        $this->onConsume($event);
+
+        Assert::notSame(Context::getCurrent(), $previousContext);
+        Assert::notNull(
+            Context::getCurrent()->get(SpanContextKey::instance()),
+            'The context was not propagated.',
+        );
+    }
+
+    private function createEnveloppeWithTraceContextStamp(): Envelope
+    {
+        return (new Envelope(new \stdClass()))->with(new TraceContextStamp());
+    }
+}

--- a/spec/Tracing/Propagation/Messenger/TraceContextStampSpec.php
+++ b/spec/Tracing/Propagation/Messenger/TraceContextStampSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation\Tracing\Propagation\Messenger;
+
+use OpenTelemetry\API\Trace\NonRecordingSpan;
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\TraceState;
+use PhpSpec\ObjectBehavior;
+
+class TraceContextStampSpec extends ObjectBehavior
+{
+    public function it_fails_when_there_is_no_parent_trace(): void
+    {
+        $this->shouldThrow(\Throwable::class)->duringInstantiation();
+    }
+
+    public function it_creates_stamp_without_state(): void
+    {
+        $span = new NonRecordingSpan(SpanContext::create(
+            'b23f37322b169de7bcaf63b9f84b1427',
+            '3c17130d40834256',
+        ));
+        $scope = $span->activate();
+
+        $this->getTraceParent()->shouldBe('00-b23f37322b169de7bcaf63b9f84b1427-3c17130d40834256-00');
+        $this->getTraceState()->shouldBe(null);
+
+        $scope->detach();
+        $span->end();
+    }
+
+    public function it_creates_stamp_with_state(): void
+    {
+        $span = new NonRecordingSpan(SpanContext::create(
+            'b23f37322b169de7bcaf63b9f84b1427',
+            '3c17130d40834256',
+            SpanContext::TRACE_FLAG_DEFAULT,
+            (new TraceState())->with('key', 'value'),
+        ));
+        $scope = $span->activate();
+
+        $this->getTraceParent()->shouldBe('00-b23f37322b169de7bcaf63b9f84b1427-3c17130d40834256-00');
+        $this->getTraceState()->shouldBe('key=value');
+
+        $scope->detach();
+        $span->end();
+    }
+}

--- a/spec/Tracing/Propagation/Messenger/TraceContextStampSpec.php
+++ b/spec/Tracing/Propagation/Messenger/TraceContextStampSpec.php
@@ -7,6 +7,7 @@
 
 namespace spec\Instrumentation\Tracing\Propagation\Messenger;
 
+use Instrumentation\Tracing\Propagation\Exception\ContextPropagationException;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\TraceState;
@@ -16,7 +17,9 @@ class TraceContextStampSpec extends ObjectBehavior
 {
     public function it_fails_when_there_is_no_parent_trace(): void
     {
-        $this->shouldThrow(\Throwable::class)->duringInstantiation();
+        $this->shouldThrow(
+            ContextPropagationException::becauseNoParentTrace(),
+        )->duringInstantiation();
     }
 
     public function it_creates_stamp_without_state(): void

--- a/src/Tracing/Propagation/Exception/ContextPropagationException.php
+++ b/src/Tracing/Propagation/Exception/ContextPropagationException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Tracing\Propagation\Exception;
+
+final class ContextPropagationException extends \RuntimeException
+{
+    public static function becauseNoParentTrace(): self
+    {
+        return new self(
+            'The context could not be propagated because no parent trace was found.'
+            .' Make sure to activate a span before trying to propagate the context.'
+        );
+    }
+}

--- a/src/Tracing/Propagation/Messenger/TraceContextStamp.php
+++ b/src/Tracing/Propagation/Messenger/TraceContextStamp.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Tracing\Propagation\Messenger;
 
+use Instrumentation\Tracing\Propagation\Exception\ContextPropagationException;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
@@ -21,6 +22,10 @@ final class TraceContextStamp implements StampInterface
     {
         $traceContext = [];
         TraceContextPropagator::getInstance()->inject($traceContext);
+
+        if (!isset($traceContext[TraceContextPropagator::TRACEPARENT])) {
+            throw ContextPropagationException::becauseNoParentTrace();
+        }
 
         $this->traceParent = $traceContext[TraceContextPropagator::TRACEPARENT];
         $this->traceState = $traceContext[TraceContextPropagator::TRACESTATE] ?? null;


### PR DESCRIPTION
As we discussed, the `TraceContextStamp` creation should not failed with a simple warning as it's currently the case.  
So I added a dedicated exception when failing to propagate a trace.

In addition, no trace operation should ever stop the main process. So all operations must failed "silently".
Instead of letting the error buble up to the client code, I catch any errors and log them as warning.