### PR TITLE
Detach context in instrumentation listeners and fix some errors when a span does not exist

### DIFF
--- a/spec/Baggage/Propagation/EventSubscriber/MessengerEventSubscriberSpec.php
+++ b/spec/Baggage/Propagation/EventSubscriber/MessengerEventSubscriberSpec.php
@@ -10,6 +10,7 @@ namespace spec\Instrumentation\Baggage\Propagation\EventSubscriber;
 use Instrumentation\Baggage\Propagation\Messenger\BaggageStamp;
 use OpenTelemetry\API\Baggage\Baggage;
 use PhpSpec\ObjectBehavior;
+use spec\Instrumentation\IsolateContext;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
@@ -18,6 +19,18 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 
 class MessengerEventSubscriberSpec extends ObjectBehavior
 {
+    use IsolateContext;
+
+    public function let(): void
+    {
+        $this->forkMainContext();
+    }
+
+    public function letGo(): void
+    {
+        $this->restoreMainContext();
+    }
+
     public function it_is_initializable(): void
     {
         $this->beAnInstanceOf(MessengerEventSubscriber::class);

--- a/spec/Baggage/Propagation/EventSubscriber/RequestEventSubscriberSpec.php
+++ b/spec/Baggage/Propagation/EventSubscriber/RequestEventSubscriberSpec.php
@@ -13,12 +13,21 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use spec\Instrumentation\IsolateContext;
 
 class RequestEventSubscriberSpec extends ObjectBehavior
 {
+    use IsolateContext;
+
     public function let()
     {
+        $this->forkMainContext();
         Baggage::getEmpty()->activate();
+    }
+
+    public function letGo(): void
+    {
+        $this->restoreMainContext();
     }
 
     public function it_is_initializable(): void

--- a/spec/Baggage/Propagation/EventSubscriber/RequestEventSubscriberSpec.php
+++ b/spec/Baggage/Propagation/EventSubscriber/RequestEventSubscriberSpec.php
@@ -9,11 +9,11 @@ namespace spec\Instrumentation\Baggage\Propagation\EventSubscriber;
 
 use OpenTelemetry\API\Baggage\Baggage;
 use PhpSpec\ObjectBehavior;
+use spec\Instrumentation\IsolateContext;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use spec\Instrumentation\IsolateContext;
 
 class RequestEventSubscriberSpec extends ObjectBehavior
 {

--- a/spec/Baggage/Propagation/Http/BaggageHeaderProviderSpec.php
+++ b/spec/Baggage/Propagation/Http/BaggageHeaderProviderSpec.php
@@ -10,12 +10,22 @@ namespace spec\Instrumentation\Baggage\Propagation\Http;
 use Instrumentation\Baggage\Propagation\Http\BaggageHeaderProvider;
 use OpenTelemetry\API\Baggage\Baggage;
 use PhpSpec\ObjectBehavior;
+use spec\Instrumentation\IsolateContext;
 
 class BaggageHeaderProviderSpec extends ObjectBehavior
 {
+    use IsolateContext;
+
     public function let()
     {
+        $this->forkMainContext();
+
         Baggage::getBuilder()->set('foo', 'bar')->build()->activate();
+    }
+
+    public function letGo(): void
+    {
+        $this->restoreMainContext();
     }
 
     public function it_is_initializable(): void

--- a/spec/Baggage/Propagation/Messenger/BaggageStampSpec.php
+++ b/spec/Baggage/Propagation/Messenger/BaggageStampSpec.php
@@ -10,13 +10,23 @@ namespace spec\Instrumentation\Baggage\Propagation\Messenger;
 use Instrumentation\Baggage\Propagation\Messenger\BaggageStamp;
 use OpenTelemetry\API\Baggage\Baggage;
 use PhpSpec\ObjectBehavior;
+use spec\Instrumentation\IsolateContext;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 class BaggageStampSpec extends ObjectBehavior
 {
+    use IsolateContext;
+
     public function let()
     {
+        $this->forkMainContext();
+
         Baggage::getBuilder()->set('foo', 'bar')->build()->activate();
+    }
+
+    public function letGo(): void
+    {
+        $this->restoreMainContext();
     }
 
     public function it_is_initializable(): void

--- a/spec/IsolateContext.php
+++ b/spec/IsolateContext.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation;
+
+use OpenTelemetry\Context\Context;
+
+trait IsolateContext
+{
+    public function forkMainContext(): void
+    {
+        // For our tests to run in isolation we need them to use different contexts
+        Context::storage()->fork(8534);
+        Context::storage()->switch(8534);
+    }
+
+    public function restoreMainContext(): void
+    {
+        Context::storage()->destroy(8534);
+        // Switch back to the main context since the ID no longer exist
+        Context::storage()->switch(8534);
+    }
+}

--- a/spec/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriberSpec.php
@@ -116,6 +116,18 @@ class CommandEventSubscriberSpec extends ObjectBehavior
         $span->end()->shouldHaveBeenCalled();
     }
 
+    public function it_does_nothing_when_error_happens_before_console_event_was_sent(
+        SpanInterface $span,
+    ): void {
+        $this->shouldNotThrow()->duringOnError($this->createConsoleErrorEvent());
+        $this->shouldNotThrow()->duringOnSignal();
+        $this->shouldNotThrow()->duringOnTerminate();
+
+        $span->recordException(Argument::type(\Throwable::class))->shouldNotHaveBeenCalled();
+        $span->setStatus(StatusCode::STATUS_ERROR)->shouldNotHaveBeenCalled();
+        $span->end()->shouldNotHaveBeenCalled();
+    }
+
     private function createConsoleCommandEvent(Command|null $command = null): ConsoleCommandEvent
     {
         return new ConsoleCommandEvent($command, new ArrayInput([]), new NullOutput());

--- a/spec/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriberSpec.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation\Tracing\Instrumentation\EventSubscriber;
+
+use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\TracerInterface;
+use OpenTelemetry\API\Trace\SpanBuilderInterface;
+use OpenTelemetry\API\Trace\SpanInterface;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\Context\ScopeInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CommandEventSubscriberSpec extends ObjectBehavior
+{
+    private MainSpanContext $mainSpanContext;
+
+    public function let(
+        TracerProviderInterface $tracerProvider,
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+        ScopeInterface $scope,
+    ): void {
+        $tracerProvider->getTracer('io.opentelemetry.contrib.php')->willReturn($tracer);
+
+        $tracer->spanBuilder(Argument::type('string'))->willReturn($spanBuilder);
+        $spanBuilder->setAttributes(Argument::type('iterable'))->willReturn($spanBuilder);
+        $spanBuilder->startSpan()->willReturn($span);
+        $span->activate()->willReturn($scope);
+        $span->recordException(Argument::type(\Throwable::class))->willReturn($span);
+        $span->setStatus(Argument::cetera())->willReturn($span);
+
+        $this->beConstructedWith(
+            $tracerProvider,
+            $this->mainSpanContext = new MainSpanContext(),
+        );
+    }
+
+    public function it_starts_new_span_when_receiving_event_for_a_named_command(
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+    ): void {
+        $this->onCommand($this->createConsoleCommandEvent(new Command('test:cmd')));
+
+        $tracer->spanBuilder('cli test:cmd')->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes(['command' => 'test:cmd'])->shouldHaveBeenCalled();
+        $span->activate()->shouldHaveBeenCalled();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
+    }
+
+    public function it_starts_new_span_when_receiving_event_for_an_unnamed_command(
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+    ): void {
+        $this->onCommand($this->createConsoleCommandEvent(new Command()));
+
+        $tracer->spanBuilder('cli unknown-command')->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes(['command' => 'unknown-command'])->shouldHaveBeenCalled();
+        $span->activate()->shouldHaveBeenCalled();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
+    }
+
+    public function it_starts_new_span_when_receiving_event_without_a_command(
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+    ): void {
+        $this->onCommand($this->createConsoleCommandEvent());
+
+        $tracer->spanBuilder('cli unknown-command')->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes(['command' => 'unknown-command'])->shouldHaveBeenCalled();
+        $span->activate()->shouldHaveBeenCalled();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
+    }
+
+    public function it_updates_span_when_receiving_error_event(SpanInterface $span): void
+    {
+        $this->onCommand($this->createConsoleCommandEvent());
+        $errorEvent = $this->createConsoleErrorEvent();
+
+        $this->onError($errorEvent);
+
+        $span->recordException($errorEvent->getError())->shouldHaveBeenCalled();
+        $span->setStatus(StatusCode::STATUS_ERROR)->shouldHaveBeenCalled();
+    }
+
+    public function it_closes_span_when_receiving_a_terminating_signal(SpanInterface $span): void
+    {
+        $this->onCommand($this->createConsoleCommandEvent());
+
+        $this->onSignal();
+
+        $span->end()->shouldHaveBeenCalled();
+    }
+
+    public function it_closes_span_when_receiving_terminate_event(SpanInterface $span): void
+    {
+        $this->onCommand($this->createConsoleCommandEvent());
+
+        $this->onTerminate();
+
+        $span->end()->shouldHaveBeenCalled();
+    }
+
+    private function createConsoleCommandEvent(Command|null $command = null): ConsoleCommandEvent
+    {
+        return new ConsoleCommandEvent($command, new ArrayInput([]), new NullOutput());
+    }
+
+    private function createConsoleErrorEvent(Command|null $command = null): ConsoleErrorEvent
+    {
+        return new ConsoleErrorEvent(new ArrayInput([]), new NullOutput(), new \Exception());
+    }
+}

--- a/spec/Tracing/Instrumentation/EventSubscriber/MessageEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/MessageEventSubscriberSpec.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation\Tracing\Instrumentation\EventSubscriber;
+
+use Instrumentation\Semantics\Attribute\MessageAttributeProviderInterface;
+use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\Messenger\AttributesStamp;
+use Instrumentation\Tracing\Instrumentation\Messenger\OperationNameStamp;
+use Instrumentation\Tracing\TracerInterface;
+use OpenTelemetry\API\Trace\SpanBuilderInterface;
+use OpenTelemetry\API\Trace\SpanInterface;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+
+class MessageEventSubscriberSpec extends ObjectBehavior
+{
+    private MainSpanContext $mainSpanContext;
+
+    public function let(
+        TracerProviderInterface $tracerProvider,
+        SpanProcessorInterface $spanProcessor,
+        MessageAttributeProviderInterface $attributeProvider,
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+        ScopeInterface $scope,
+    ): void {
+        $tracerProvider->getTracer('io.opentelemetry.contrib.php')->willReturn($tracer);
+        $tracer->spanBuilder(Argument::type('string'))->willReturn($spanBuilder);
+        $spanBuilder->setSpanKind(Argument::type('int'))->willReturn($spanBuilder);
+        $spanBuilder->setAttributes(Argument::type('iterable'))->willReturn($spanBuilder);
+        $spanBuilder->startSpan()->willReturn($span);
+        $span->activate()->willReturn($scope);
+        $span->recordException(Argument::cetera())->willReturn($span);
+        $span->setStatus(Argument::cetera())->willReturn($span);
+
+        $spanProcessor->forceFlush()->willReturn(true);
+
+        $attributeProvider->getAttributes(Argument::type(Envelope::class))->willReturn([
+            'from_provider' => 'value',
+        ]);
+
+        $this->beConstructedWith(
+            $tracerProvider,
+            $spanProcessor,
+            $attributeProvider,
+            $this->mainSpanContext = new MainSpanContext(),
+        );
+    }
+
+    public function it_starts_a_new_span_when_receiving_a_message(
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+    ): void {
+        $envelope = new Envelope(new \stdClass());
+
+        $this->onConsume(new WorkerMessageReceivedEvent($envelope, 'receiver name'));
+
+        $tracer->spanBuilder('message.stdClass process')->shouldHaveBeenCalled();
+        $spanBuilder->setSpanKind(SpanKind::KIND_CONSUMER)->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes([
+            'from_provider' => 'value',
+            'messaging.operation' => 'process',
+            'messaging.consumer_id' => gethostname(),
+            'messaging.destination' => 'receiver name',
+            'messenger.message' => 'stdClass',
+        ])->shouldHaveBeenCalled();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
+    }
+
+    public function it_starts_a_new_span_when_receiving_a_message_with_operation_name_stamp(
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+    ): void {
+        $envelope = new Envelope(new \stdClass(), [new OperationNameStamp('operation_name')]);
+
+        $this->onConsume(new WorkerMessageReceivedEvent($envelope, 'receiver name'));
+
+        $tracer->spanBuilder('message.operation_name process')->shouldHaveBeenCalled();
+        $spanBuilder->setSpanKind(SpanKind::KIND_CONSUMER)->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes([
+            'from_provider' => 'value',
+            'messaging.operation' => 'process',
+            'messaging.consumer_id' => gethostname(),
+            'messaging.destination' => 'receiver name',
+            'messenger.message' => 'stdClass',
+        ])->shouldHaveBeenCalled();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
+    }
+
+    public function it_starts_a_new_span_when_receiving_a_message_with_bus_name_stamp(
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+    ): void {
+        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('bus_name')]);
+
+        $this->onConsume(new WorkerMessageReceivedEvent($envelope, 'receiver name'));
+
+        $tracer->spanBuilder('message.stdClass process')->shouldHaveBeenCalled();
+        $spanBuilder->setSpanKind(SpanKind::KIND_CONSUMER)->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes([
+            'from_provider' => 'value',
+            'messaging.operation' => 'process',
+            'messaging.consumer_id' => gethostname(),
+            'messaging.destination' => 'receiver name',
+            'messenger.message' => 'stdClass',
+            'messenger.bus' => 'bus_name',
+        ])->shouldHaveBeenCalled();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
+    }
+
+    public function it_starts_a_new_span_when_receiving_a_message_with_attributes_stamp(
+        TracerInterface $tracer,
+        SpanBuilderInterface $spanBuilder,
+        SpanInterface $span,
+    ): void {
+        $envelope = new Envelope(new \stdClass(), [new AttributesStamp([
+            'from_stamp' => 'value',
+        ])]);
+
+        $this->onConsume(new WorkerMessageReceivedEvent($envelope, 'receiver name'));
+
+        $tracer->spanBuilder('message.stdClass process')->shouldHaveBeenCalled();
+        $spanBuilder->setSpanKind(SpanKind::KIND_CONSUMER)->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes([
+            'from_provider' => 'value',
+            'messaging.operation' => 'process',
+            'messaging.consumer_id' => gethostname(),
+            'messaging.destination' => 'receiver name',
+            'messenger.message' => 'stdClass',
+            'from_stamp' => 'value',
+        ])->shouldHaveBeenCalled();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
+    }
+
+    public function it_saves_and_clean_the_span_when_message_has_been_handled(
+        SpanInterface $span,
+        SpanProcessorInterface $spanProcessor,
+    ): void {
+        $envelope = new Envelope(new \stdClass());
+        $this->onConsume(new WorkerMessageReceivedEvent($envelope, 'receiver name'));
+
+        $this->onHandled(new WorkerMessageHandledEvent($envelope, 'receiver name'));
+
+        $span->end()->shouldHaveBeenCalled();
+        $spanProcessor->forceFlush()->shouldHaveBeenCalled();
+    }
+
+    public function it_saves_and_clean_the_span_when_message_has_failed(
+        SpanInterface $span,
+        SpanProcessorInterface $spanProcessor,
+    ): void {
+        $envelope = new Envelope(new \stdClass());
+        $this->onConsume(new WorkerMessageReceivedEvent($envelope, 'receiver name'));
+        $failedEvent = new WorkerMessageFailedEvent($envelope, 'receiver name', new \Exception());
+
+        $this->onHandled($failedEvent);
+
+        $span->recordException($failedEvent->getThrowable())->shouldHaveBeenCalled();
+        $span->setStatus(StatusCode::STATUS_ERROR)->shouldHaveBeenCalled();
+        $span->end()->shouldHaveBeenCalled();
+        $spanProcessor->forceFlush()->shouldHaveBeenCalled();
+    }
+}

--- a/spec/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriberSpec.php
@@ -1,0 +1,352 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation\Tracing\Instrumentation\EventSubscriber;
+
+use Instrumentation\Semantics\Attribute\ServerRequestAttributeProvider;
+use Instrumentation\Semantics\Attribute\ServerRequestAttributeProviderInterface;
+use Instrumentation\Semantics\Attribute\ServerResponseAttributeProvider;
+use Instrumentation\Semantics\Attribute\ServerResponseAttributeProviderInterface;
+use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\TracerInterface;
+use OpenTelemetry\API\Trace\SpanBuilderInterface;
+use OpenTelemetry\API\Trace\SpanInterface;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\SemConv\TraceAttributes;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Collaborator;
+use Prophecy\Argument;
+use spec\Instrumentation\IsolateContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+class RequestEventSubscriberSpec extends ObjectBehavior
+{
+    private HttpKernelInterface|Collaborator $kernel;
+    private array $requestAttributes = ['request' => 'attribute'];
+    private array $responseAttributes = ['first' => 'attribute', 'second' => 'attribute'];
+    private MainSpanContext $mainSpanContext;
+    private RouteCollection $routeCollection;
+
+    public function let(
+        HttpKernelInterface $kernel,
+        TracerInterface $tracer,
+        SpanBuilderInterface $serverSpanBuilder,
+        SpanInterface $serverSpan,
+        ScopeInterface $serverScope,
+        SpanBuilderInterface $requestSpanBuilder,
+        SpanInterface $requestSpan,
+        ScopeInterface $requestScope,
+        TracerProviderInterface $tracerProvider,
+        RouterInterface $router,
+        ServerRequestAttributeProviderInterface $requestAttributeProvider,
+        ServerResponseAttributeProviderInterface $responseAttributeProvider,
+    ): void {
+        $this->kernel = $kernel;
+        $router->getRouteCollection()->willReturn($this->routeCollection = new RouteCollection());
+
+        $requestAttributeProvider->getAttributes(Argument::type(Request::class))->willReturn(
+            $this->requestAttributes,
+        );
+        $responseAttributeProvider->getAttributes(Argument::type(Response::class))->willReturn(
+            $this->responseAttributes,
+        );
+
+        $tracerProvider->getTracer('io.opentelemetry.contrib.php')->willReturn($tracer);
+
+        $tracer->spanBuilder('server')->willReturn($serverSpanBuilder);
+        $serverSpanBuilder->setSpanKind(SpanKind::KIND_SERVER)->willReturn($serverSpanBuilder);
+        $serverSpanBuilder->setStartTimestamp(Argument::type('int'))->willReturn($serverSpanBuilder);
+        $serverSpanBuilder->startSpan()->willReturn($serverSpan);
+        $serverSpan->activate()->willReturn($serverScope);
+        $serverSpan->updateName(Argument::type('string'))->willReturn($serverSpan);
+        $serverSpan->setAttributes($this->requestAttributes)->willReturn($serverSpan);
+        $serverSpan->setAttribute(Argument::cetera())->willReturn($serverSpan);
+        $serverSpan->setStatus(Argument::cetera())->willReturn($serverSpan);
+
+        $this->configureRequestSpanBuilder($tracer, $requestSpanBuilder, $requestSpan);
+        $requestSpan->activate()->willReturn($requestScope);
+
+        $this->beConstructedWith(
+            $tracerProvider,
+            $router,
+            $requestAttributeProvider,
+            $responseAttributeProvider,
+            $this->mainSpanContext = new MainSpanContext(),
+        );
+    }
+
+    public function it_creates_server_span_and_request_span_when_receiving_request_for_the_first_time(
+        SpanBuilderInterface $serverSpanBuilder,
+        SpanInterface $serverSpan,
+        SpanInterface $requestSpan,
+    ): void {
+        $mainRequestEvent = $this->createMainRequestEvent('/test/{id}', Request::METHOD_PUT);
+        $startTime = 1656320753.1187;
+        $mainRequestEvent->getRequest()->server->set('REQUEST_TIME_FLOAT', $startTime);
+
+        $this->onRequestEvent($mainRequestEvent);
+
+        $serverSpanBuilder->setStartTimestamp($startTime * 1000 ** 3)->shouldHaveBeenCalled();
+        $serverSpan->activate()->shouldHaveBeenCalled();
+        $serverSpan->updateName('http.put /test/{id}')->shouldHaveBeenCalled();
+        $serverSpan->setAttributes($this->requestAttributes)->shouldHaveBeenCalled();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($serverSpan);
+        $requestSpan->activate()->shouldHaveBeenCalled();
+    }
+
+    public function it_only_creates_request_span_when_receiveing_sub_request(
+        SpanInterface $serverSpan,
+        TracerInterface $tracer,
+        SpanBuilderInterface $subRequestSpanBuilder,
+        SpanInterface $subRequestSpan,
+    ): void {
+        $mainRequestEvent = $this->createMainRequestEvent('/test/{id}', Request::METHOD_PUT);
+        $subRequestEvent = $this->createSubRequestEvent('/sub-request', Request::METHOD_GET);
+        $this->onRequestEvent($mainRequestEvent);
+        $this->configureRequestSpanBuilder($tracer, $subRequestSpanBuilder, $subRequestSpan);
+
+        $this->onRequestEvent($subRequestEvent);
+
+        $serverSpan->activate()->shouldHaveBeenCalledOnce();
+        $serverSpan->updateName('http.put /test/{id}')->shouldHaveBeenCalledOnce();
+        expect($this->mainSpanContext->getMainSpan())->shouldBe($serverSpan);
+        $subRequestSpanBuilder->startSpan()->shouldHaveBeenCalled();
+        $subRequestSpan->activate()->shouldNotHaveBeenCalled();
+    }
+
+    public function it_updates_main_request_span_when_controller_is_resolved(SpanInterface $requestSpan): void
+    {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $request = $mainRequestEvent->getRequest();
+        $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
+        $this->onRequestEvent($mainRequestEvent);
+
+        $this->onControllerEvent($this->createControllerEvent($mainRequestEvent));
+
+        $requestSpan->updateName('sf.controller.main')->shouldHaveBeenCalled();
+        $requestSpan->setAttribute('sf.controller', 'Main::controller')->shouldHaveBeenCalled();
+        $requestSpan->setAttribute('sf.route', 'main_route')->shouldHaveBeenCalled();
+    }
+
+    public function it_updates_server_span_when_controller_is_resolved_for_main_request_with_known_route(
+        SpanInterface $serverSpan,
+    ): void {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $request = $mainRequestEvent->getRequest();
+        $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
+        $this->routeCollection->add('main_route', new Route('/test/{id}'));
+        $this->onRequestEvent($mainRequestEvent);
+
+        $this->onControllerEvent($this->createControllerEvent($mainRequestEvent));
+
+        $serverSpan->updateName('http.get /test/{id}')->shouldHaveBeenCalled();
+        $serverSpan->setAttribute(TraceAttributes::HTTP_ROUTE, '/test/{id}')->shouldHaveBeenCalled();
+    }
+
+    public function it_does_not_update_server_span_when_controller_is_resolved_for_main_request_with_unknown_route(
+        SpanInterface $serverSpan,
+    ): void {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $request = $mainRequestEvent->getRequest();
+        $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
+        $this->onRequestEvent($mainRequestEvent);
+
+        $this->onControllerEvent($this->createControllerEvent($mainRequestEvent));
+
+        $serverSpan->updateName('http.get /test/{id}')->shouldNotHaveBeenCalled();
+        $serverSpan->setAttribute(TraceAttributes::HTTP_ROUTE, '/test/{id}')->shouldNotHaveBeenCalled();
+    }
+
+    public function it_updates_sub_request_span_when_controller_is_resolved(SpanInterface $requestSpan): void
+    {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $request = $mainRequestEvent->getRequest();
+        $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
+        $subRequestEvent = $this->createSubRequestEvent('/sub-request', Request::METHOD_GET);
+        $request = $subRequestEvent->getRequest();
+        $request->attributes->add(['_controller' => 'Sub::controller', '_route' => 'sub_route']);
+        $this->onRequestEvent($mainRequestEvent);
+        $this->onRequestEvent($subRequestEvent);
+
+        $this->onControllerEvent($this->createControllerEvent($subRequestEvent));
+
+        $requestSpan->updateName('sf.controller.sub')->shouldHaveBeenCalled();
+        $requestSpan->setAttribute('sf.controller', 'Sub::controller')->shouldHaveBeenCalled();
+        $requestSpan->setAttribute('sf.route', 'sub_route')->shouldHaveBeenCalled();
+    }
+
+    public function it_does_not_update_server_span_when_controller_is_resolved_for_sub_request(
+        SpanInterface $serverSpan,
+    ): void {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $request = $mainRequestEvent->getRequest();
+        $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
+        $subRequestEvent = $this->createSubRequestEvent('/sub-request', Request::METHOD_GET);
+        $request = $subRequestEvent->getRequest();
+        $request->attributes->add(['_controller' => 'Sub::controller', '_route' => 'sub_route']);
+        $this->routeCollection->add('sub_route', new Route('/sub-request/{id}'));
+        $this->onRequestEvent($mainRequestEvent);
+        $this->onRequestEvent($subRequestEvent);
+
+        $this->onControllerEvent($this->createControllerEvent($subRequestEvent));
+
+        $serverSpan->updateName('http.get /sub-request/{id}')->shouldNotHaveBeenCalled();
+        $serverSpan->setAttribute(TraceAttributes::HTTP_ROUTE, 'sub-request')->shouldNotHaveBeenCalled();
+    }
+
+    public function it_adds_response_attributes_to_server_span(SpanInterface $serverSpan): void
+    {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $this->onRequestEvent($mainRequestEvent);
+
+        $this->onResponseEvent($this->createResponseEvent($mainRequestEvent, 200));
+
+        $serverSpan->setAttribute('first', 'attribute')->shouldHaveBeenCalled();
+        $serverSpan->setAttribute('second', 'attribute')->shouldHaveBeenCalled();
+    }
+
+    public function it_sets_server_span_status_to_error_when_responses_status_code_is_greater_than_or_equal_to_500(
+        SpanInterface $serverSpan,
+    ): void {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $this->onRequestEvent($mainRequestEvent);
+
+        $this->onResponseEvent($this->createResponseEvent($mainRequestEvent, 500));
+
+        $serverSpan->setStatus(StatusCode::STATUS_ERROR)->shouldHaveBeenCalled();
+    }
+
+    public function it_ends_span_for_the_request_once_finished(
+        TracerInterface $tracer,
+        SpanInterface $requestSpan,
+        SpanBuilderInterface $subRequestSpanBuilder,
+        SpanInterface $subRequestSpan,
+    ): void {
+        $mainRequestEvent = $this->createMainRequestEvent('/test/{id}', Request::METHOD_PUT);
+        $subRequestEvent = $this->createSubRequestEvent('/sub-request', Request::METHOD_GET);
+        $this->onRequestEvent($mainRequestEvent);
+        $this->configureRequestSpanBuilder($tracer, $subRequestSpanBuilder, $subRequestSpan);
+        $this->onRequestEvent($subRequestEvent);
+
+        $this->onFinishRequestEvent($this->createFinishRequestEvent($subRequestEvent));
+
+        $requestSpan->end()->shouldNotHaveBeenCalled();
+        $subRequestSpan->end()->shouldHaveBeenCalled();
+
+        $this->onFinishRequestEvent($this->createFinishRequestEvent($mainRequestEvent));
+        $requestSpan->end()->shouldHaveBeenCalled();
+    }
+
+    public function it_ends_span_for_the_request_and_marks_it_in_error_when_an_exception_is_catched(
+        SpanInterface $requestSpan,
+    ): void {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $this->onRequestEvent($mainRequestEvent);
+
+        $this->onExceptionEvent($this->createExceptionEvent($mainRequestEvent));
+
+        $requestSpan->setStatus(StatusCode::STATUS_ERROR)->shouldHaveBeenCalled();
+        $requestSpan->end()->shouldHaveBeenCalled();
+    }
+
+    public function it_ends_server_span_when_kernel_is_terminated(SpanInterface $serverSpan): void
+    {
+        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $this->onRequestEvent($mainRequestEvent);
+
+        $this->onTerminate();
+
+        $serverSpan->end()->shouldHaveBeenCalled();
+    }
+
+    private function createMainRequestEvent(string $path, string $method = Request::METHOD_GET): RequestEvent
+    {
+        return $this->createRequestEvent($path, $method, HttpKernelInterface::MAIN_REQUEST);
+    }
+
+    private function createSubRequestEvent(string $path, string $method = Request::METHOD_GET): RequestEvent
+    {
+        return $this->createRequestEvent($path, $method, HttpKernelInterface::SUB_REQUEST);
+    }
+
+    private function createRequestEvent(
+        string $path,
+        string $method = Request::METHOD_GET,
+        int $requestType = HttpKernelInterface::MAIN_REQUEST,
+    ): RequestEvent {
+        $request = Request::create($path, $method);
+
+        return new RequestEvent($this->kernel->getWrappedObject(), $request, $requestType);
+    }
+
+    private function configureRequestSpanBuilder(TracerInterface $tracer, SpanBuilderInterface $requestSpanBuilder, SpanInterface $requestSpan)
+    {
+        $tracer->spanBuilder('request')->willReturn($requestSpanBuilder);
+        $requestSpanBuilder->setAttributes([])->willReturn($requestSpanBuilder);
+        $requestSpanBuilder->startSpan()->willReturn($requestSpan);
+        $requestSpan->updateName(Argument::type('string'))->willReturn($requestSpan);
+        $requestSpan->setAttribute(Argument::cetera())->willReturn($requestSpan);
+        $requestSpan->setStatus(Argument::cetera())->willReturn($requestSpan);
+    }
+
+    private function createControllerEvent(RequestEvent $requestEvent): ControllerEvent
+    {
+        $callable = function () {
+        };
+
+        return new ControllerEvent(
+            $this->kernel->getWrappedObject(),
+            $callable,
+            $requestEvent->getRequest(),
+            $requestEvent->getRequestType(),
+        );
+    }
+
+    private function createResponseEvent(RequestEvent $requestEvent, int $statusCode): ResponseEvent
+    {
+        return new ResponseEvent(
+            $this->kernel->getWrappedObject(),
+            $requestEvent->getRequest(),
+            $requestEvent->getRequestType(),
+            new Response('', $statusCode),
+        );
+    }
+
+    private function createFinishRequestEvent(RequestEvent $requestEvent): FinishRequestEvent
+    {
+        return new FinishRequestEvent(
+            $this->kernel->getWrappedObject(),
+            $requestEvent->getRequest(),
+            $requestEvent->getRequestType(),
+        );
+    }
+
+    public function createExceptionEvent(RequestEvent $requestEvent): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->kernel->getWrappedObject(),
+            $requestEvent->getRequest(),
+            $requestEvent->getRequestType(),
+            new \Exception(),
+        );
+    }
+}

--- a/spec/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriberSpec.php
@@ -260,11 +260,13 @@ class RequestEventSubscriberSpec extends ObjectBehavior
         SpanInterface $requestSpan,
     ): void {
         $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $exceptionEvent = $this->createExceptionEvent($mainRequestEvent);
         $this->onRequestEvent($mainRequestEvent);
 
-        $this->onExceptionEvent($this->createExceptionEvent($mainRequestEvent));
+        $this->onExceptionEvent($exceptionEvent);
 
         $requestSpan->setStatus(StatusCode::STATUS_ERROR)->shouldHaveBeenCalled();
+        $requestSpan->recordException($exceptionEvent->getThrowable())->shouldHaveBeenCalled();
         $requestSpan->end()->shouldHaveBeenCalled();
     }
 
@@ -306,6 +308,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
         $requestSpan->updateName(Argument::type('string'))->willReturn($requestSpan);
         $requestSpan->setAttribute(Argument::cetera())->willReturn($requestSpan);
         $requestSpan->setStatus(Argument::cetera())->willReturn($requestSpan);
+        $requestSpan->recordException(Argument::type(\Throwable::class))->willReturn($requestSpan);
     }
 
     private function createControllerEvent(RequestEvent $requestEvent): ControllerEvent

--- a/spec/Tracing/Propagation/Messenger/TraceContextStampSpec.php
+++ b/spec/Tracing/Propagation/Messenger/TraceContextStampSpec.php
@@ -12,9 +12,22 @@ use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\TraceState;
 use PhpSpec\ObjectBehavior;
+use spec\Instrumentation\IsolateContext;
 
 class TraceContextStampSpec extends ObjectBehavior
 {
+    use IsolateContext;
+
+    public function let(): void
+    {
+        $this->forkMainContext();
+    }
+
+    public function letGo(): void
+    {
+        $this->restoreMainContext();
+    }
+
     public function it_fails_when_there_is_no_parent_trace(): void
     {
         $this->shouldThrow(

--- a/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
@@ -24,7 +24,7 @@ class CommandEventSubscriber implements EventSubscriberInterface
 {
     use TracerAwareTrait;
 
-    private SpanInterface $span;
+    private ?SpanInterface $span = null;
 
     public static function getSubscribedEvents(): array
     {
@@ -52,17 +52,23 @@ class CommandEventSubscriber implements EventSubscriberInterface
 
     public function onError(ConsoleErrorEvent $event): void
     {
-        $this->span->recordException($event->getError());
-        $this->span->setStatus(StatusCode::STATUS_ERROR);
+        $this->span?->recordException($event->getError());
+        $this->span?->setStatus(StatusCode::STATUS_ERROR);
     }
 
     public function onSignal(): void
     {
-        $this->span->end();
+        $this->closeTrace();
     }
 
     public function onTerminate(): void
     {
-        $this->span->end();
+        $this->closeTrace();
+    }
+
+    private function closeTrace(): void
+    {
+        $this->span?->end();
+        $this->span = null;
     }
 }

--- a/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
@@ -135,6 +135,7 @@ class RequestEventSubscriber implements EventSubscriberInterface
     public function onExceptionEvent(Event\ExceptionEvent $event): void
     {
         $span = $this->getSpanForRequest($event->getRequest());
+        $span->recordException($event->getThrowable());
         $span->setStatus(StatusCode::STATUS_ERROR);
         $span->end();
     }


### PR DESCRIPTION
Just like for the previous PR we have issues with the instrumentation listeners which are not correct detaching the contexts they creates when activating a span.

While at it I also fixed another issue we encountered:
In some cases we can receive a `ConsoleErrorEvent` without having received any `ConsoleCommandEvent`. Which means we will try to end a span which was actually never even created and this will throw an error.