### PR TITLE
Fix/metrics storage prefix

### DIFF
--- a/spec/Metrics/Storage/RedisPrefixProviderSpec.php
+++ b/spec/Metrics/Storage/RedisPrefixProviderSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation\Metrics\Storage;
+
+use PhpSpec\ObjectBehavior;
+
+class RedisPrefixProviderSpec extends ObjectBehavior
+{
+    public function it_provides_the_metrics_prefix_for_redis_storage(): void
+    {
+        $this->beConstructedThrough('getInstance');
+
+        $this->prefix()->shouldBe('metrics:'.gethostname());
+    }
+}

--- a/src/DependencyInjection/config/metrics/metrics.php
+++ b/src/DependencyInjection/config/metrics/metrics.php
@@ -59,5 +59,14 @@ return static function (ContainerConfigurator $container) {
         ->autoconfigure()
         ->args([
             service(Metrics\RegistryInterface::class),
-        ]);
+        ])
+
+        ->set(Metrics\Storage\RedisPrefixProvider::class)
+        ->factory([Metrics\Storage\RedisPrefixProvider::class, 'getInstance'])
+
+        ->set(Metrics\Storage\HostnamePrefixedRedisFactory::class)
+        ->args([
+            service(Metrics\Storage\RedisPrefixProvider::class),
+        ])
+    ;
 };

--- a/src/Metrics/Storage/HostnamePrefixedRedisFactory.php
+++ b/src/Metrics/Storage/HostnamePrefixedRedisFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Metrics\Storage;
+
+use Prometheus\Storage\Redis as RedisAdapter;
+use Redis as RedisConnection;
+
+final class HostnamePrefixedRedisFactory
+{
+    public function __construct(private ?RedisPrefixProvider $redisPrefixProvider)
+    {
+    }
+
+    public function createFromExistingConnection(RedisConnection $connection): RedisAdapter
+    {
+        $adapter = RedisAdapter::fromExistingConnection($connection);
+
+        if (null !== $this->redisPrefixProvider) {
+            $adapter->setPrefix($this->redisPrefixProvider->prefix());
+        }
+
+        return $adapter;
+    }
+}

--- a/src/Metrics/Storage/RedisPrefixProvider.php
+++ b/src/Metrics/Storage/RedisPrefixProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Metrics\Storage;
+
+class RedisPrefixProvider
+{
+    protected static ?RedisPrefixProvider $instance = null;
+    protected string $prefix;
+
+    protected function __construct()
+    {
+        if (false === $hostname = gethostname()) {
+            throw new \RuntimeException('Impossible to retrieve the hostname.');
+        }
+
+        $this->prefix = "metrics:$hostname";
+    }
+
+    public function prefix(): string
+    {
+        return $this->prefix;
+    }
+
+    public static function getInstance(): self
+    {
+        if (null === static::$instance) {
+            static::$instance = new self();
+        }
+
+        return static::$instance;
+    }
+}


### PR DESCRIPTION
We can't define the prefix using the hostname in the extension because we want the hostname to be resolved at runtime.

To make it easier to reuse the prefix somewhere else I also introduced a service responsible to provide the prefix to use for the metrics.