### PR TITLE
Handle anonymous user tokens in `symfony` < `6.x`

### DIFF
--- a/spec/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriberSpec.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation\Tracing\Instrumentation\EventSubscriber;
+
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
+use OpenTelemetry\API\Trace\SpanInterface;
+use OpenTelemetry\SemConv\TraceAttributes;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Collaborator;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class AddUserEventSubscriberSpec extends ObjectBehavior
+{
+    private HttpKernelInterface|Collaborator $kernel;
+
+    public function let(
+        HttpKernelInterface $kernel
+    ): void {
+        $this->kernel = $kernel;
+    }
+
+    public function it_should_add_user_if_authenticated(
+        SpanInterface $requestSpan,
+        TokenStorageInterface $tokenStorage,
+        UsernamePasswordToken $usernamePasswordToken,
+        MainSpanContextInterface $mainSpanContext,
+        UserInterface $user
+    ): void {
+        $user->getRoles()->willReturn(['ADMIN']);
+        $user->getUserIdentifier()->willReturn('David');
+        $usernamePasswordToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($usernamePasswordToken);
+        $this->setupRequestSpan($requestSpan, $mainSpanContext);
+        $this->beConstructedWith(
+            $mainSpanContext,
+            $tokenStorage
+        );
+        $mainRequestEvent = $this->createRequestEvent('/somewhere/{id}', Request::METHOD_PUT);
+        $this->onRequestEvent($mainRequestEvent);
+        $requestSpan->setAttribute(TraceAttributes::ENDUSER_ID, 'David')->shouldHaveBeenCalled();
+        $requestSpan->setAttribute(TraceAttributes::ENDUSER_ROLE, ['ADMIN'])->shouldHaveBeenCalled();
+    }
+
+    private function setupRequestSpan(SpanInterface $requestSpan, MainSpanContextInterface $mainSpanContext)
+    {
+        $requestSpan->setAttribute(Argument::cetera())->willReturn($requestSpan);
+        $mainSpanContext->getMainSpan()->willReturn($requestSpan);
+    }
+
+    private function createRequestEvent(
+        string $path,
+        string $method = Request::METHOD_GET,
+    ): RequestEvent {
+        $request = Request::create($path, $method);
+
+        return new RequestEvent($this->kernel->getWrappedObject(), $request, HttpKernelInterface::MAIN_REQUEST);
+    }
+}

--- a/src/DependencyInjection/config/tracing/command.php
+++ b/src/DependencyInjection/config/tracing/command.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Instrumentation\Resources;
 
 use Instrumentation\Tracing;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -21,7 +21,7 @@ return static function (ContainerConfigurator $container) {
         ->set(Tracing\Instrumentation\EventSubscriber\CommandEventSubscriber::class)
         ->args([
             service(TracerProviderInterface::class),
-            service(MainSpanContext::class),
+            service(MainSpanContextInterface::class),
         ])
         ->autoconfigure();
 };

--- a/src/DependencyInjection/config/tracing/doctrine.php
+++ b/src/DependencyInjection/config/tracing/doctrine.php
@@ -11,7 +11,7 @@ namespace Instrumentation\Resources;
 
 use Instrumentation\Semantics\Attribute\DoctrineConnectionAttributeProviderInterface;
 use Instrumentation\Tracing;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -23,6 +23,6 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service(TracerProviderInterface::class),
             service(DoctrineConnectionAttributeProviderInterface::class),
-            service(MainSpanContext::class),
+            service(MainSpanContextInterface::class),
         ]);
 };

--- a/src/DependencyInjection/config/tracing/message.php
+++ b/src/DependencyInjection/config/tracing/message.php
@@ -11,7 +11,7 @@ namespace Instrumentation\Resources;
 
 use Instrumentation\Semantics\Attribute\MessageAttributeProviderInterface;
 use Instrumentation\Tracing;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -28,7 +28,7 @@ return static function (ContainerConfigurator $container) {
             service(TracerProviderInterface::class),
             service(SpanProcessorInterface::class),
             service(MessageAttributeProviderInterface::class),
-            service(MainSpanContext::class),
+            service(MainSpanContextInterface::class),
         ])
         ->autoconfigure();
 };

--- a/src/DependencyInjection/config/tracing/request.php
+++ b/src/DependencyInjection/config/tracing/request.php
@@ -12,7 +12,7 @@ namespace Instrumentation\Resources;
 use Instrumentation\Semantics\Attribute\ServerRequestAttributeProviderInterface;
 use Instrumentation\Semantics\Attribute\ServerResponseAttributeProviderInterface;
 use Instrumentation\Tracing;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use Instrumentation\Tracing\Propagation\ForcableIdGenerator;
 use Instrumentation\Tracing\Propagation\IncomingTraceHeaderResolverInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
@@ -38,13 +38,13 @@ return static function (ContainerConfigurator $container) {
             service(RouterInterface::class),
             service(ServerRequestAttributeProviderInterface::class),
             service(ServerResponseAttributeProviderInterface::class),
-            service(MainSpanContext::class),
+            service(MainSpanContextInterface::class),
         ])
         ->autoconfigure()
 
         ->set(Tracing\Instrumentation\EventSubscriber\AddUserEventSubscriber::class)
         ->args([
-            service(MainSpanContext::class),
+            service(MainSpanContextInterface::class),
             service(TokenStorageInterface::class)->nullOnInvalid(),
         ])
         ->autoconfigure();

--- a/src/DependencyInjection/config/tracing/tracing.php
+++ b/src/DependencyInjection/config/tracing/tracing.php
@@ -16,6 +16,7 @@ use Instrumentation\Tracing\Factory\SpanProcessorFactory;
 use Instrumentation\Tracing\Instrumentation\EventSubscriber\ToggleTracerSubscriber;
 use Instrumentation\Tracing\Instrumentation\LogHandler\TracingHandler;
 use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use Instrumentation\Tracing\Propagation\ForcableIdGenerator;
 use Instrumentation\Tracing\Propagation\IncomingTraceHeaderResolverInterface;
 use Instrumentation\Tracing\Propagation\RegexIncomingTraceHeaderResolver;
@@ -113,7 +114,7 @@ return static function (ContainerConfigurator $container) {
         ->set(TracingHandler::class)
         ->args([
             service(TracerProviderInterface::class),
-            service(MainSpanContext::class),
+            service(MainSpanContextInterface::class),
             param('tracing.logs.level'),
             param('tracing.logs.channels'),
         ])

--- a/src/DependencyInjection/config/tracing/tracing.php
+++ b/src/DependencyInjection/config/tracing/tracing.php
@@ -109,7 +109,7 @@ return static function (ContainerConfigurator $container) {
         ])
         ->autoconfigure()
 
-        ->set(MainSpanContext::class)
+        ->set(MainSpanContextInterface::class, MainSpanContext::class)
 
         ->set(TracingHandler::class)
         ->args([

--- a/src/Tracing/Instrumentation/Doctrine/DBAL/Connection.php
+++ b/src/Tracing/Instrumentation/Doctrine/DBAL/Connection.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use Instrumentation\Tracing\Instrumentation\TracerAwareTrait;
 use OpenTelemetry\API\Trace\SpanContextKey;
 use OpenTelemetry\API\Trace\SpanKind;
@@ -38,7 +38,7 @@ final class Connection implements ServerInfoAwareConnection
     /**
      * @param array<string,string> $attributes
      */
-    public function __construct(protected TracerProviderInterface $tracerProvider, protected ConnectionInterface $decorated, private MainSpanContext $mainSpanContext, private array $attributes)
+    public function __construct(protected TracerProviderInterface $tracerProvider, protected ConnectionInterface $decorated, private MainSpanContextInterface $mainSpanContext, private array $attributes)
     {
     }
 

--- a/src/Tracing/Instrumentation/Doctrine/DBAL/Driver.php
+++ b/src/Tracing/Instrumentation/Doctrine/DBAL/Driver.php
@@ -17,12 +17,12 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 use Instrumentation\Semantics\Attribute\DoctrineConnectionAttributeProviderInterface;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 
 final class Driver implements VersionAwarePlatformDriver
 {
-    public function __construct(private TracerProviderInterface $tracerProvider, private DoctrineConnectionAttributeProviderInterface $attributeProvider, private DriverInterface $decorated, private MainSpanContext $mainSpanContext)
+    public function __construct(private TracerProviderInterface $tracerProvider, private DoctrineConnectionAttributeProviderInterface $attributeProvider, private DriverInterface $decorated, private MainSpanContextInterface $mainSpanContext)
     {
     }
 

--- a/src/Tracing/Instrumentation/Doctrine/DBAL/Middleware.php
+++ b/src/Tracing/Instrumentation/Doctrine/DBAL/Middleware.php
@@ -12,12 +12,12 @@ namespace Instrumentation\Tracing\Instrumentation\Doctrine\DBAL;
 use Doctrine\DBAL\Driver as BaseDriver;
 use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 use Instrumentation\Semantics\Attribute\DoctrineConnectionAttributeProviderInterface;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 
 final class Middleware implements MiddlewareInterface
 {
-    public function __construct(private TracerProviderInterface $tracerProvider, private DoctrineConnectionAttributeProviderInterface $attributeProvider, private MainSpanContext $mainSpanContext)
+    public function __construct(private TracerProviderInterface $tracerProvider, private DoctrineConnectionAttributeProviderInterface $attributeProvider, private MainSpanContextInterface $mainSpanContext)
     {
     }
 

--- a/src/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriber.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Tracing\Instrumentation\EventSubscriber;
 
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use Instrumentation\Tracing\Instrumentation\TracerAwareTrait;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -30,7 +30,7 @@ final class AddUserEventSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function __construct(private MainSpanContext $mainSpanContext, private ?TokenStorageInterface $tokenStorage = null)
+    public function __construct(private MainSpanContextInterface $mainSpanContext, private ?TokenStorageInterface $tokenStorage = null)
     {
     }
 
@@ -49,7 +49,6 @@ final class AddUserEventSubscriber implements EventSubscriberInterface
         if ($token && $this->isTokenAuthenticated($token)) {
             $span = $this->mainSpanContext->getMainSpan();
             $user = $token->getUser();
-
             if ($user) {
                 $span->setAttribute(TraceAttributes::ENDUSER_ID, $this->getUsername($user));
                 $span->setAttribute(TraceAttributes::ENDUSER_ROLE, $this->getRoles($user));

--- a/src/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriber.php
@@ -56,6 +56,9 @@ final class AddUserEventSubscriber implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @return string[]
+     */
     private function getRoles(UserInterface|string $user): array
     {
         if ($user instanceof UserInterface) {

--- a/src/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriber.php
@@ -52,15 +52,21 @@ final class AddUserEventSubscriber implements EventSubscriberInterface
 
             if ($user) {
                 $span->setAttribute(TraceAttributes::ENDUSER_ID, $this->getUsername($user));
-                $span->setAttribute(TraceAttributes::ENDUSER_ROLE, $user->getRoles());
+                $span->setAttribute(TraceAttributes::ENDUSER_ROLE, $this->getRoles($user));
             }
         }
     }
 
-    /**
-     * @param UserInterface|object|string $user
-     */
-    private function getUsername($user): ?string
+    private function getRoles(UserInterface|string $user): array
+    {
+        if ($user instanceof UserInterface) {
+            return $user->getRoles();
+        }
+
+        return [];
+    }
+
+    private function getUsername(UserInterface|string $user): ?string
     {
         if ($user instanceof UserInterface) {
             if (method_exists($user, 'getUserIdentifier')) {

--- a/src/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/AddUserEventSubscriber.php
@@ -59,7 +59,7 @@ final class AddUserEventSubscriber implements EventSubscriberInterface
     /**
      * @return string[]
      */
-    private function getRoles(UserInterface|string $user): array
+    private function getRoles(UserInterface|\Stringable|string $user): array
     {
         if ($user instanceof UserInterface) {
             return $user->getRoles();
@@ -68,7 +68,7 @@ final class AddUserEventSubscriber implements EventSubscriberInterface
         return [];
     }
 
-    private function getUsername(UserInterface|string $user): ?string
+    private function getUsername(UserInterface|\Stringable|string $user): ?string
     {
         if ($user instanceof UserInterface) {
             if (method_exists($user, 'getUserIdentifier')) {

--- a/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Tracing\Instrumentation\EventSubscriber;
 
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use Instrumentation\Tracing\Instrumentation\TracerAwareTrait;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\StatusCode;
@@ -38,7 +38,7 @@ class CommandEventSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function __construct(protected TracerProviderInterface $tracerProvider, protected MainSpanContext $mainSpanContext)
+    public function __construct(protected TracerProviderInterface $tracerProvider, protected MainSpanContextInterface $mainSpanContext)
     {
     }
 

--- a/src/Tracing/Instrumentation/EventSubscriber/MessageEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/MessageEventSubscriber.php
@@ -8,7 +8,7 @@
 namespace Instrumentation\Tracing\Instrumentation\EventSubscriber;
 
 use Instrumentation\Semantics\Attribute\MessageAttributeProviderInterface;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use Instrumentation\Tracing\Instrumentation\Messenger\AttributesStamp;
 use Instrumentation\Tracing\Instrumentation\Messenger\OperationNameStamp;
 use Instrumentation\Tracing\Instrumentation\TracerAwareTrait;
@@ -48,7 +48,7 @@ class MessageEventSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function __construct(protected TracerProviderInterface $tracerProvider, protected SpanProcessorInterface $spanProcessor, protected MessageAttributeProviderInterface $attributeProvider, protected MainSpanContext $mainSpanContext)
+    public function __construct(protected TracerProviderInterface $tracerProvider, protected SpanProcessorInterface $spanProcessor, protected MessageAttributeProviderInterface $attributeProvider, protected MainSpanContextInterface $mainSpanContext)
     {
         $this->scopes = new \SplObjectStorage();
     }

--- a/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
@@ -11,7 +11,7 @@ namespace Instrumentation\Tracing\Instrumentation\EventSubscriber;
 
 use Instrumentation\Semantics\Attribute\ServerRequestAttributeProviderInterface;
 use Instrumentation\Semantics\Attribute\ServerResponseAttributeProviderInterface;
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use Instrumentation\Tracing\Instrumentation\TracerAwareTrait;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
@@ -60,7 +60,7 @@ class RequestEventSubscriber implements EventSubscriberInterface
         protected RouterInterface $router,
         protected ServerRequestAttributeProviderInterface $requestAttributeProvider,
         protected ServerResponseAttributeProviderInterface $responseAttributeProvider,
-        protected MainSpanContext $mainSpanContext
+        protected MainSpanContextInterface $mainSpanContext
     ) {
         $this->spans = new \SplObjectStorage();
         $this->scopes = new \SplObjectStorage();

--- a/src/Tracing/Instrumentation/LogHandler/TracingHandler.php
+++ b/src/Tracing/Instrumentation/LogHandler/TracingHandler.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Tracing\Instrumentation\LogHandler;
 
-use Instrumentation\Tracing\Instrumentation\MainSpanContext;
+use Instrumentation\Tracing\Instrumentation\MainSpanContextInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
@@ -24,7 +24,7 @@ class TracingHandler extends AbstractProcessingHandler
     /**
      * @param array<string> $channels
      */
-    public function __construct(protected TracerProviderInterface $tracerProvider, protected MainSpanContext $mainSpanContext, $level = Logger::INFO, private array $channels = [], private string $strategy = self::STRATEGY_MAIN_SPAN, bool $bubble = true)
+    public function __construct(protected TracerProviderInterface $tracerProvider, protected MainSpanContextInterface $mainSpanContext, $level = Logger::INFO, private array $channels = [], private string $strategy = self::STRATEGY_MAIN_SPAN, bool $bubble = true)
     {
         parent::__construct($level, $bubble);
 

--- a/src/Tracing/Instrumentation/MainSpanContext.php
+++ b/src/Tracing/Instrumentation/MainSpanContext.php
@@ -12,7 +12,7 @@ namespace Instrumentation\Tracing\Instrumentation;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\SDK\Trace\Span;
 
-final class MainSpanContext
+final class MainSpanContext implements MainSpanContextInterface
 {
     private ?SpanInterface $mainSpan = null;
 

--- a/src/Tracing/Instrumentation/MainSpanContextInterface.php
+++ b/src/Tracing/Instrumentation/MainSpanContextInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Tracing\Instrumentation;
+
+use OpenTelemetry\API\Trace\SpanInterface;
+
+interface MainSpanContextInterface
+{
+    public function getMainSpan(): SpanInterface;
+}

--- a/src/Tracing/Instrumentation/MainSpanContextInterface.php
+++ b/src/Tracing/Instrumentation/MainSpanContextInterface.php
@@ -14,4 +14,8 @@ use OpenTelemetry\API\Trace\SpanInterface;
 interface MainSpanContextInterface
 {
     public function getMainSpan(): SpanInterface;
+
+    public function setMainSpan(SpanInterface $span): void;
+
+    public function setCurrent(): void;
 }


### PR DESCRIPTION
Thank you first for this bundle!

This PR adds support for older symfony versions (particular `< 6`).

The current implementation throws an error when accessing `getRoles()` on a `string`.
So I adjusted it to check before pulling them (similar what `getUsername` was already doing)

I further added (basic) tests for the user instrumentation. To make tests easier I introduced a new interface `MainSpanContextInterface`.

In general compatibility of this bundle is unclear as it's always pulling in the latest symfony version and there is no`composer.lock` file (worth another PR?), but as symfony `5.4` is the latest lts I think it would make sense to support that.
