### PR TITLE
fix: do not use "getRouteCollection()" to get the route path

### DIFF
--- a/spec/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriberSpec.php
@@ -139,7 +139,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
 
     public function it_updates_main_request_span_when_controller_is_resolved(SpanInterface $requestSpan): void
     {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $request = $mainRequestEvent->getRequest();
         $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
         $this->onRequestEvent($mainRequestEvent);
@@ -154,7 +154,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
     public function it_updates_server_span_when_controller_is_resolved_for_main_request_with_known_route(
         SpanInterface $serverSpan,
     ): void {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $request = $mainRequestEvent->getRequest();
         $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
         $this->routeCollection->add('main_route', new Route('/test/{id}'));
@@ -169,7 +169,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
     public function it_does_not_update_server_span_when_controller_is_resolved_for_main_request_with_unknown_route(
         SpanInterface $serverSpan,
     ): void {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $request = $mainRequestEvent->getRequest();
         $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
         $this->onRequestEvent($mainRequestEvent);
@@ -182,7 +182,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
 
     public function it_updates_sub_request_span_when_controller_is_resolved(SpanInterface $requestSpan): void
     {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $request = $mainRequestEvent->getRequest();
         $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
         $subRequestEvent = $this->createSubRequestEvent('/sub-request', Request::METHOD_GET);
@@ -201,10 +201,10 @@ class RequestEventSubscriberSpec extends ObjectBehavior
     public function it_does_not_update_server_span_when_controller_is_resolved_for_sub_request(
         SpanInterface $serverSpan,
     ): void {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $request = $mainRequestEvent->getRequest();
         $request->attributes->add(['_controller' => 'Main::controller', '_route' => 'main_route']);
-        $subRequestEvent = $this->createSubRequestEvent('/sub-request', Request::METHOD_GET);
+        $subRequestEvent = $this->createSubRequestEvent('/sub-request/1', Request::METHOD_GET);
         $request = $subRequestEvent->getRequest();
         $request->attributes->add(['_controller' => 'Sub::controller', '_route' => 'sub_route']);
         $this->routeCollection->add('sub_route', new Route('/sub-request/{id}'));
@@ -219,7 +219,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
 
     public function it_adds_response_attributes_to_server_span(SpanInterface $serverSpan): void
     {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $this->onRequestEvent($mainRequestEvent);
 
         $this->onResponseEvent($this->createResponseEvent($mainRequestEvent, 200));
@@ -231,7 +231,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
     public function it_sets_server_span_status_to_error_when_responses_status_code_is_greater_than_or_equal_to_500(
         SpanInterface $serverSpan,
     ): void {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $this->onRequestEvent($mainRequestEvent);
 
         $this->onResponseEvent($this->createResponseEvent($mainRequestEvent, 500));
@@ -266,7 +266,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
         ScopeInterface $requestScope,
         SpanInterface $requestSpan,
     ): void {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $exceptionEvent = $this->createExceptionEvent($mainRequestEvent);
         $this->onRequestEvent($mainRequestEvent);
 
@@ -282,7 +282,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
         ScopeInterface $serverScope,
         SpanInterface $serverSpan,
     ): void {
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
         $this->onRequestEvent($mainRequestEvent);
 
         $this->onTerminate();
@@ -302,7 +302,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
             new ServerResponseAttributeProvider(),
             new MainSpanContext(),
         );
-        $mainRequestEvent = $this->createMainRequestEvent('/test');
+        $mainRequestEvent = $this->createMainRequestEvent('/test/1');
 
         $this->onRequestEvent($mainRequestEvent);
         $this->onFinishRequestEvent($this->createFinishRequestEvent($mainRequestEvent));

--- a/src/DependencyInjection/Extension.php
+++ b/src/DependencyInjection/Extension.php
@@ -225,6 +225,7 @@ class Extension extends BaseExtension implements CompilerPassInterface, PrependE
 
         $loader->load('tracing.php');
         $loader->load('http.php');
+        $loader->load('routing.php');
 
         if (isset($config['trace_url'])) {
             $container->register(TraceUrlGeneratorInterface::class)

--- a/src/DependencyInjection/config/tracing/request.php
+++ b/src/DependencyInjection/config/tracing/request.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Resources;
 
+use Instrumentation\Routing\RoutePathResolver;
 use Instrumentation\Semantics\Attribute\ServerRequestAttributeProviderInterface;
 use Instrumentation\Semantics\Attribute\ServerResponseAttributeProviderInterface;
 use Instrumentation\Tracing;
@@ -20,7 +21,6 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 return static function (ContainerConfigurator $container) {
@@ -35,7 +35,7 @@ return static function (ContainerConfigurator $container) {
         ->set(Tracing\Instrumentation\EventSubscriber\RequestEventSubscriber::class)
         ->args([
             service(TracerProviderInterface::class),
-            service(RouterInterface::class),
+            service(RoutePathResolver::class),
             service(ServerRequestAttributeProviderInterface::class),
             service(ServerResponseAttributeProviderInterface::class),
             service(MainSpanContextInterface::class),

--- a/src/DependencyInjection/config/tracing/routing.php
+++ b/src/DependencyInjection/config/tracing/routing.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Resources;
+
+use Instrumentation\Routing\RouteCacheWarmer;
+use Instrumentation\Routing\RoutePathResolver;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+use Symfony\Component\Routing\RouterInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set(RouteCacheWarmer::class)
+        ->args([
+            service(RouterInterface::class),
+        ])
+        ->autoconfigure()
+
+        ->set(RoutePathResolver::class)
+        ->args([
+            service(RouterInterface::class),
+            param('kernel.cache_dir'),
+        ])
+        ->autoconfigure()
+    ;
+};

--- a/src/Routing/RouteCacheWarmer.php
+++ b/src/Routing/RouteCacheWarmer.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Routing;
+
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class RouteCacheWarmer implements CacheWarmerInterface
+{
+    public const ROUTE_PATHS_CACHE_FILE = 'route_paths.php';
+
+    public function __construct(
+        private RouterInterface $router,
+    ) {
+    }
+
+    public function isOptional()
+    {
+        return true;
+    }
+
+    public function warmUp(string $cacheDir)
+    {
+        $routes = [];
+        foreach ($this->router->getRouteCollection() as $name => $route) {
+            $routes[$name] = $route->getPath();
+        }
+
+        $content = '<?php return '.var_export($routes, true).';'.\PHP_EOL;
+        file_put_contents($cacheDir.\DIRECTORY_SEPARATOR.self::ROUTE_PATHS_CACHE_FILE, $content);
+
+        return [];
+    }
+}

--- a/src/Routing/RoutePathResolver.php
+++ b/src/Routing/RoutePathResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Routing;
+
+use Symfony\Component\Routing\RouterInterface;
+
+class RoutePathResolver implements RoutePathResolverInterface
+{
+    public function __construct(
+        private RouterInterface $router,
+        private string $cacheDir,
+    ) {
+    }
+
+    public function resolve(string $routeName): ?string
+    {
+        // if the cache is not warmed up, then regenerate it and return the corresponding path
+        if (!file_exists($routePathCacheFilename = $this->cacheDir.'/'.RouteCacheWarmer::ROUTE_PATHS_CACHE_FILE)) {
+            return $this->router->getRouteCollection()->get($routeName)?->getPath();
+        }
+
+        // get the route path from the cache
+        $routePaths = require $routePathCacheFilename;
+
+        return $routePaths[$routeName] ?? null;
+    }
+}

--- a/src/Routing/RoutePathResolverInterface.php
+++ b/src/Routing/RoutePathResolverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Routing;
+
+interface RoutePathResolverInterface
+{
+    public function resolve(string $routeName): ?string;
+}


### PR DESCRIPTION
Reduce execution time by avoiding to resolve the controller a second time to get the route path (-10ms in prod mode on my machine).

Consequences :
- The trace title displayed in jaeger is now the resolved path instead of the pattern (ex: `/rooms/{method}` => `/rooms/find`)
- The `http_route` attribute is no longer present (but we still have the complete URL and controller name in the attributes)

I also remove the test `it_does_not_update_server_span_when_controller_is_resolved_for_main_request_with_unknown_route`. It is useless because the event `kernel.controller` will never be dispatched if the controller is not resolved.