### PR TITLE
feat: add kernel boot time as tracing attribute

### DIFF
--- a/spec/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriberSpec.php
@@ -57,7 +57,7 @@ class CommandEventSubscriberSpec extends ObjectBehavior
         $this->onCommand($this->createConsoleCommandEvent(new Command('test:cmd')));
 
         $tracer->spanBuilder('cli test:cmd')->shouldHaveBeenCalled();
-        $spanBuilder->setAttributes(['command' => 'test:cmd'])->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes(Argument::allOf(Argument::withEntry('command', 'test:cmd'), Argument::withKey('sf.kernel_boot_duration')))->shouldHaveBeenCalled();
         $span->activate()->shouldHaveBeenCalled();
         expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
     }
@@ -70,7 +70,7 @@ class CommandEventSubscriberSpec extends ObjectBehavior
         $this->onCommand($this->createConsoleCommandEvent(new Command()));
 
         $tracer->spanBuilder('cli unknown-command')->shouldHaveBeenCalled();
-        $spanBuilder->setAttributes(['command' => 'unknown-command'])->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes(Argument::allOf(Argument::withEntry('command', 'unknown-command'), Argument::withKey('sf.kernel_boot_duration')))->shouldHaveBeenCalled();
         $span->activate()->shouldHaveBeenCalled();
         expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
     }
@@ -83,7 +83,7 @@ class CommandEventSubscriberSpec extends ObjectBehavior
         $this->onCommand($this->createConsoleCommandEvent());
 
         $tracer->spanBuilder('cli unknown-command')->shouldHaveBeenCalled();
-        $spanBuilder->setAttributes(['command' => 'unknown-command'])->shouldHaveBeenCalled();
+        $spanBuilder->setAttributes(Argument::allOf(Argument::withEntry('command', 'unknown-command'), Argument::withKey('sf.kernel_boot_duration')))->shouldHaveBeenCalled();
         $span->activate()->shouldHaveBeenCalled();
         expect($this->mainSpanContext->getMainSpan())->shouldBe($span);
     }

--- a/spec/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriberSpec.php
@@ -80,7 +80,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
         $serverSpanBuilder->startSpan()->willReturn($serverSpan);
         $serverSpan->activate()->willReturn($serverScope);
         $serverSpan->updateName(Argument::type('string'))->willReturn($serverSpan);
-        $serverSpan->setAttributes($this->requestAttributes)->willReturn($serverSpan);
+        $serverSpan->setAttributes(Argument::withKey('request'))->willReturn($serverSpan);
         $serverSpan->setAttribute(Argument::cetera())->willReturn($serverSpan);
         $serverSpan->setStatus(Argument::cetera())->willReturn($serverSpan);
         $serverScope->detach()->willReturn(0);
@@ -112,7 +112,7 @@ class RequestEventSubscriberSpec extends ObjectBehavior
         $serverSpanBuilder->setStartTimestamp($startTime * 1000 ** 3)->shouldHaveBeenCalled();
         $serverSpan->activate()->shouldHaveBeenCalled();
         $serverSpan->updateName('http.put /test/{id}')->shouldHaveBeenCalled();
-        $serverSpan->setAttributes($this->requestAttributes)->shouldHaveBeenCalled();
+        $serverSpan->setAttributes(Argument::allOf(Argument::withEntry('request', 'attribute'), Argument::withKey('sf.kernel_boot_duration')))->shouldHaveBeenCalled();
         expect($this->mainSpanContext->getMainSpan())->shouldBe($serverSpan);
         $requestSpan->activate()->shouldHaveBeenCalled();
     }

--- a/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
@@ -46,7 +46,10 @@ class CommandEventSubscriber implements EventSubscriberInterface
     {
         $name = $event->getCommand()?->getName() ?: 'unknown-command';
 
-        $this->span = $this->startSpan(sprintf('cli %s', $name), ['command' => $name]);
+        $startTime = $_SERVER['REQUEST_TIME_FLOAT'] ?? microtime(true); // Float with microsecond precision
+        $kernelBootTime = round(microtime(true) - $startTime, 3);
+
+        $this->span = $this->startSpan(sprintf('cli %s', $name), ['command' => $name, 'sf.kernel_boot_duration' => $kernelBootTime]);
         $this->scope = $this->span->activate();
 
         $this->mainSpanContext->setMainSpan($this->span);

--- a/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
@@ -69,14 +69,12 @@ class RequestEventSubscriber implements EventSubscriberInterface
     public function onRequestEvent(Event\RequestEvent $event): void
     {
         $request = $event->getRequest();
+        $startTime = $request->server->get('REQUEST_TIME_FLOAT'); // Float with microsecond precision
 
         if (!$this->serverSpan) {
-            $startTime = $request->server->get('REQUEST_TIME_FLOAT'); // Float with microsecond precision
-            $startTime = (int) ($startTime * 1000 * 1000 * 1000); // Convert to nanoseconds
-
             $this->serverSpan = $this->getTracer()->spanBuilder('server')
                 ->setSpanKind(SpanKind::KIND_SERVER)
-                ->setStartTimestamp($startTime)
+                ->setStartTimestamp((int) ($startTime * 1000 * 1000 * 1000))  // Convert to nanoseconds
                 ->startSpan();
 
             $this->serverScope = $this->serverSpan->activate();
@@ -86,6 +84,7 @@ class RequestEventSubscriber implements EventSubscriberInterface
 
         if ($event->isMainRequest()) {
             $attributes = $this->requestAttributeProvider->getAttributes($request);
+            $attributes['sf.kernel_boot_duration'] = round(microtime(true) - $startTime, 3);
 
             $this->serverSpan->updateName(sprintf('http.%s %s', strtolower($request->getMethod()), $request->getPathInfo()));
             $this->serverSpan->setAttributes($attributes);


### PR DESCRIPTION
Add `sf.kernel_boot_duration` attribute to the trace containing the elapsed time between the very beginning of the request and the dispatch of the `kernel.request` event (in HTTP) or the `kernel.console` event (in CLI), representing the booting duration of the Symfony Kernel.
This is useful when we try to improve the Symfony configuration to speed up the kernel boot.