### PR TITLE
chore: update tracing subscribers priorities

### DIFF
--- a/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
@@ -31,10 +31,10 @@ class CommandEventSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ConsoleCommandEvent::class => [['onCommand', 100]],
-            ConsoleErrorEvent::class => [['onError', -100]],
-            ConsoleTerminateEvent::class => [['onTerminate', -100]],
-            ConsoleSignalEvent::class => [['onSignal', -100]],
+            ConsoleCommandEvent::class => [['onCommand', 512]], // before all SF listeners
+            ConsoleErrorEvent::class => [['onError', -512]],
+            ConsoleTerminateEvent::class => [['onTerminate', -512]],
+            ConsoleSignalEvent::class => [['onSignal', -512]],
         ];
     }
 

--- a/src/Tracing/Instrumentation/EventSubscriber/MessageEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/MessageEventSubscriber.php
@@ -43,9 +43,9 @@ class MessageEventSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            WorkerMessageReceivedEvent::class => [['onConsume', 100]],
-            WorkerMessageHandledEvent::class => [['onHandled', -100]],
-            WorkerMessageFailedEvent::class => [['onHandled', -100]],
+            WorkerMessageReceivedEvent::class => [['onConsume', 512]], // before all SF listeners
+            WorkerMessageHandledEvent::class => [['onHandled', -512]],
+            WorkerMessageFailedEvent::class => [['onHandled', -512]],
         ];
     }
 

--- a/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
@@ -47,7 +47,7 @@ class RequestEventSubscriber implements EventSubscriberInterface
     {
         return [
             KernelEvents::REQUEST => [
-                ['onRequestEvent', 512], // before all SF listeners
+                ['onRequestEvent', 512], // before all Symfony listeners
                 ['onRouteResolved', 31], // right after Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest()
             ],
             KernelEvents::RESPONSE => ['onResponseEvent'],

--- a/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
@@ -46,12 +46,14 @@ class RequestEventSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => [['onRequestEvent', 100]],
-            KernelEvents::CONTROLLER => ['onControllerEvent'],
+            KernelEvents::REQUEST => [
+                ['onRequestEvent', 512], // before all SF listeners
+                ['onRouteResolved', 31], // right after Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest()
+            ],
             KernelEvents::RESPONSE => ['onResponseEvent'],
-            KernelEvents::FINISH_REQUEST => [['onFinishRequestEvent', -100]],
-            KernelEvents::EXCEPTION => [['onExceptionEvent', -100]],
-            KernelEvents::TERMINATE => [['onTerminate', -100]],
+            KernelEvents::FINISH_REQUEST => [['onFinishRequestEvent', -512]],
+            KernelEvents::EXCEPTION => [['onExceptionEvent', -512]],
+            KernelEvents::TERMINATE => [['onTerminate', -512]],
         ];
     }
 
@@ -94,7 +96,7 @@ class RequestEventSubscriber implements EventSubscriberInterface
         $this->startSpanForRequest($request, $event->isMainRequest());
     }
 
-    public function onControllerEvent(Event\ControllerEvent $event): void
+    public function onRouteResolved(Event\RequestEvent $event): void
     {
         $request = $event->getRequest();
 


### PR DESCRIPTION
The attribute `sf.controller` will be set on `kernel.request` event.

Regarding 404s : 
- if the route is resolved, but the resource is not (ex: `api.worldia.loc/inspirations/9999`), the span will be named from the route path (ex: `/inspirations/{id}`)
- if the route is not resolved (ex: `api.worldia.loc/rooms/pouet`), the span will be named from the URI (ex: `/rooms/pouet`)