### PR TITLE
Fix cast to float parameter

### DIFF
--- a/spec/Tracing/Factory/SamplerFactorySpec.php
+++ b/spec/Tracing/Factory/SamplerFactorySpec.php
@@ -43,6 +43,21 @@ class SamplerFactorySpec extends ObjectBehavior
         $sampler->getDescription()->shouldReturn('ParentBased+AlwaysOffSampler');
     }
 
+    public function it_creates_samplers_from_url(): void
+    {
+        $sampler = $this->createFromDsn('scheme://host');
+        $sampler->shouldReturnAnInstanceOf(ParentBased::class);
+        $sampler->getDescription()->shouldReturn('ParentBased+AlwaysOnSampler');
+
+        $sampler = $this->createFromDsn('scheme://host?type=parentbased_always_off');
+        $sampler->shouldReturnAnInstanceOf(ParentBased::class);
+        $sampler->getDescription()->shouldReturn('ParentBased+AlwaysOffSampler');
+
+        $sampler = $this->createFromDsn('scheme://host?type=parentbased_traceidratio&ratio=0.2');
+        $sampler->shouldReturnAnInstanceOf(ParentBased::class);
+        $sampler->getDescription()->shouldReturn('ParentBased+TraceIdRatioBasedSampler{0.200000}');
+    }
+
     public function it_throws_an_exception_with_needed_ratio_is_not_provided(): void
     {
         $this->shouldThrow(\RuntimeException::class)->during('create', ['traceidratio']);

--- a/src/Tracing/Factory/SamplerFactory.php
+++ b/src/Tracing/Factory/SamplerFactory.php
@@ -46,7 +46,7 @@ class SamplerFactory
     {
         $dsn = DsnParser::parseUrl($dsn);
         $type = $dsn->getParameter('sampler', self::PARENTBASED_ALWAYS_ON);
-        $ratio = $dsn->getParameter('ratio', .5);
+        $ratio = (float) $dsn->getParameter('ratio', .5);
 
         return $this->create($type, $ratio);
     }


### PR DESCRIPTION
Because the `create` requires a `float`, `$dsn->getParameter` returns a `string` and class has `declare(strict_types=1);`, the `createFromDsn method fails when passing a ratio in the DSN