### PR TITLE
Add a NullExporter

### DIFF
--- a/src/Tracing/Exporter/NullExporter.php
+++ b/src/Tracing/Exporter/NullExporter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Tracing\Exporter;
+
+use OpenTelemetry\SDK\Common\Future\CancellationInterface;
+use OpenTelemetry\SDK\Common\Future\CompletedFuture;
+use OpenTelemetry\SDK\Common\Future\FutureInterface;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+
+class NullExporter implements SpanExporterInterface
+{
+    public static function fromConnectionString(string $endpointUrl, string $name, string $args)
+    {
+        return new self();
+    }
+
+    public function export(iterable $spans, ?CancellationInterface $cancellation = null): FutureInterface
+    {
+        return new CompletedFuture(SpanExporterInterface::STATUS_SUCCESS);
+    }
+
+    public function shutdown(?CancellationInterface $cancellation = null): bool
+    {
+        return true;
+    }
+
+    public function forceFlush(?CancellationInterface $cancellation = null): bool
+    {
+        return true;
+    }
+}

--- a/src/Tracing/Factory/ExporterFactory.php
+++ b/src/Tracing/Factory/ExporterFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Tracing\Factory;
 
+use Instrumentation\Tracing\Exporter\NullExporter;
 use Nyholm\Dsn\DsnParser;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\ExporterFactory as BaseExporterFactory;
@@ -29,6 +30,10 @@ class ExporterFactory
     public function createFromDsn(string $dsn): SpanExporterInterface
     {
         $dsn = DsnParser::parseUrl($dsn);
+
+        if ('null' === $dsn->getScheme()) {
+            return new NullExporter();
+        }
 
         $url = $dsn
             ->withParameter('serviceName', $this->serviceName)


### PR DESCRIPTION
This PR adds a new Export That does nothing. It helps to disable the Export in some conditions (staging, test, ...).

I know users can use `type=parentbased_always_off` to disable the sampler, but that still require to provide an exporter in the DSN (ie. `jaeger+http://a-fake-host:9411/api/v2/spans?type=parentbased_always_off`