### PR TITLE
ShutDown tracer before exiting

### DIFF
--- a/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriber.php
@@ -16,6 +16,7 @@ use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\SDK\Trace\TracerProvider;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleSignalEvent;
@@ -78,5 +79,9 @@ class CommandEventSubscriber implements EventSubscriberInterface
         $this->scope?->detach();
         $this->span?->end();
         $this->span = null;
+
+        if ($this->tracerProvider instanceof TracerProvider) {
+            $this->tracerProvider->shutdown();
+        }
     }
 }

--- a/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
+++ b/src/Tracing/Instrumentation/EventSubscriber/RequestEventSubscriber.php
@@ -20,6 +20,7 @@ use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\Context\ScopeInterface;
 use OpenTelemetry\SDK\Trace\Span;
+use OpenTelemetry\SDK\Trace\TracerProvider;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event;
@@ -138,6 +139,10 @@ class RequestEventSubscriber implements EventSubscriberInterface
     {
         $this->serverScope?->detach();
         $this->serverSpan?->end();
+
+        if ($this->tracerProvider instanceof TracerProvider) {
+            $this->tracerProvider->shutdown();
+        }
     }
 
     public function onExceptionEvent(Event\ExceptionEvent $event): void


### PR DESCRIPTION
From https://github.com/open-telemetry/opentelemetry-php/issues/852#issuecomment-1301006790 calling the shutdown method is necessary.

This PR ensure the method is called at the end of a request and a command