### PR TITLE
fix: detach scope when response is received in TracingHttpClient

### DIFF
--- a/src/Http/TracingHttpClient.php
+++ b/src/Http/TracingHttpClient.php
@@ -54,10 +54,10 @@ final class TracingHttpClient implements HttpClientInterface
             ])
             ->startSpan();
 
-        $span->activate();
+        $scope = $span->activate();
 
         $options = array_merge($options, [
-            'on_progress' => function ($dlNow, $dlSize, $info) use ($onProgress, $span) {
+            'on_progress' => function ($dlNow, $dlSize, $info) use ($onProgress, $span, $scope) {
                 if (null !== $onProgress) {
                     $onProgress($dlNow, $dlSize, $info);
                 }
@@ -70,6 +70,7 @@ final class TracingHttpClient implements HttpClientInterface
                         $span->setStatus(StatusCode::STATUS_ERROR);
                     }
 
+                    $scope->detach();
                     $span->end();
                 }
             },


### PR DESCRIPTION
This fixes span nesting in `TracingHttpClient`

Before :
<img width="321" alt="before" src="https://user-images.githubusercontent.com/3588995/204253643-1e3991ba-c40b-481f-ab8e-8e4fcb3781ed.png">

After : 
<img width="316" alt="after" src="https://user-images.githubusercontent.com/3588995/204253647-47f41547-ff06-4828-9a0c-31df567433c7.png">
