### PR TITLE
fix: TracingHttpClient span duration

### DIFF
--- a/src/Http/TracedResponse.php
+++ b/src/Http/TracedResponse.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Http;
+
+use OpenTelemetry\API\Trace\SpanInterface;
+use Symfony\Component\HttpClient\Response\StreamableInterface;
+use Symfony\Component\HttpClient\Response\StreamWrapper;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class TracedResponse implements ResponseInterface, StreamableInterface
+{
+    public function __construct(
+        private ResponseInterface $response,
+        private SpanInterface $span
+    ) {
+    }
+
+    public function __destruct()
+    {
+        $this->endTracing();
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    public function getHeaders(bool $throw = true): array
+    {
+        return $this->response->getHeaders($throw);
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        try {
+            return $this->response->getContent($throw);
+        } finally {
+            $this->endTracing();
+        }
+    }
+
+    /**
+     * @return array<int,mixed>
+     */
+    public function toArray(bool $throw = true): array
+    {
+        try {
+            return $this->response->toArray($throw);
+        } finally {
+            $this->endTracing();
+        }
+    }
+
+    public function cancel(): void
+    {
+        try {
+            $this->response->cancel();
+        } finally {
+            $this->endTracing();
+        }
+    }
+
+    public function getInfo(string $type = null): mixed
+    {
+        return $this->response->getInfo($type);
+    }
+
+    public function toStream(bool $throw = true)
+    {
+        if ($throw) {
+            // Ensure headers arrived
+            $this->response->getHeaders();
+        }
+
+        if ($this->response instanceof StreamableInterface) {
+            return $this->response->toStream(false);
+        }
+
+        return StreamWrapper::createResource($this->response);
+    }
+
+    protected function endTracing(): void
+    {
+        $endEpochNanos = null;
+
+        /** @var array<string,mixed> $info */
+        $info = $this->response->getInfo();
+        if (isset($info['start_time'], $info['total_time'])) {
+            $endEpochNanos = (int) (($info['start_time'] + $info['total_time']) * 1_000_000_000);
+        }
+
+        $this->span->end($endEpochNanos);
+    }
+}

--- a/src/Semantics/Attribute/ClientRequestAttributeProvider.php
+++ b/src/Semantics/Attribute/ClientRequestAttributeProvider.php
@@ -26,6 +26,7 @@ class ClientRequestAttributeProvider implements ClientRequestAttributeProviderIn
             TraceAttributes::PEER_SERVICE => $peerName,
             TraceAttributes::HTTP_SERVER_NAME => $peerName,
             TraceAttributes::HTTP_METHOD => strtoupper($method),
+            TraceAttributes::HTTP_URL => $url,
         ];
 
         foreach ($this->capturedHeaders as $header) {

--- a/src/Semantics/OperationName/ClientRequestOperationNameResolver.php
+++ b/src/Semantics/OperationName/ClientRequestOperationNameResolver.php
@@ -13,12 +13,8 @@ class ClientRequestOperationNameResolver implements ClientRequestOperationNameRe
 {
     public function getOperationName(string $method, string $url, string $peerName): string
     {
-        $protocol = parse_url($url, \PHP_URL_SCHEME);
+        $url = parse_url($url);
 
-        if (empty($protocol)) {
-            $protocol = 'http';
-        }
-
-        return sprintf('http.%s %s://%s', strtolower($method), $protocol, $peerName);
+        return sprintf('http.%s %s://%s', strtolower($method), $url['scheme'] ?? 'http', $url['host'] ?? $peerName);
     }
 }


### PR DESCRIPTION
Hello there !

The current issue : 
The TracingHttpClient [on_request](https://github.com/worldia/instrumentation-bundle/blob/master/src/Http/TracingHttpClient.php#L68) callable set the "status_code" attribute as soon as the client receive the status code from the server. But it also ends the span at the same time. So the span does not include the content download time. For example, if the server responds in 200ms, but it takes 1s to download the content. The client will receive the status code after 200ms, and the span will have a duration of 200ms instead of 1.2s.

This PR adds : 
- Class TracedResponse that will end the span after the content is fully downloaded.
- static boolean `$dlStarted` in the "on_progress" callback to avoid adding attributes twice
- `int $maxHostConnections` and `int $maxPendingPushes` to constructor argument to match with `HttpClient::create()` signature.

Before :
<img width="388" alt="before" src="https://user-images.githubusercontent.com/3588995/205093055-9a38ac10-0b4e-438e-ac0d-8f8f37859c2d.png">
After : 
<img width="372" alt="after" src="https://user-images.githubusercontent.com/3588995/205093051-be8dba57-9150-4f5e-a08e-9b1f7fb8d389.png">
