### PR TITLE
Format HTTP headers in span attributes

### DIFF
--- a/spec/Http/HttpSensitiveDataHelperSpec.php
+++ b/spec/Http/HttpSensitiveDataHelperSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace spec\Instrumentation\Http;
+
+use PhpSpec\ObjectBehavior;
+
+class HttpSensitiveDataHelperSpec extends ObjectBehavior
+{
+    public function it_removes_credentials_from_url(): void
+    {
+        $this::filterUrl('https://root:p4ssw0rd@example.com?foo=bar#baz')->shouldReturn('https://example.com?foo=bar#baz');
+    }
+
+    public function it_removes_credentials_from_headers(): void
+    {
+        $this::filterHeaders([
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer kjfdhsfkjshgskjq',
+            'proxy-authorization' => 'Basic gperfbshkdbfzdzl',
+        ])->shouldReturn([
+            'Content-Type' => 'application/json',
+        ]);
+    }
+}

--- a/src/Http/HttpMessageHelper.php
+++ b/src/Http/HttpMessageHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Http;
+
+class HttpMessageHelper
+{
+    /**
+     * @param array<string,string[]> $headers
+     */
+    public static function formatHeadersForSpanAttribute(array $headers): string
+    {
+        $lines = [];
+        foreach ($headers as $name => $values) {
+            foreach ($values as $value) {
+                $lines[] = sprintf('%s: %s', mb_strtolower($name), $value);
+            }
+        }
+
+        return implode(\PHP_EOL, $lines);
+    }
+}

--- a/src/Http/HttpMessageHelper.php
+++ b/src/Http/HttpMessageHelper.php
@@ -16,6 +16,8 @@ class HttpMessageHelper
      */
     public static function formatHeadersForSpanAttribute(array $headers): string
     {
+        $headers = HttpSensitiveDataHelper::filterHeaders($headers);
+
         $lines = [];
         foreach ($headers as $name => $values) {
             foreach ($values as $value) {

--- a/src/Http/HttpSensitiveDataHelper.php
+++ b/src/Http/HttpSensitiveDataHelper.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\Http;
+
+use Nyholm\Psr7\Uri;
+
+class HttpSensitiveDataHelper
+{
+    private const SENSITIVE_HEADERS = [
+        'authorization',
+        'Authorization',
+        'proxy-authorization',
+        'Proxy-Authorization',
+    ];
+
+    public static function filterUrl(string $url): string
+    {
+        $url = new Uri($url);
+        $url = $url->withUserInfo('');
+
+        return (string) $url;
+    }
+
+    /**
+     * @param array<string,string[]> $headers
+     *
+     * @return array<string,string[]>
+     */
+    public static function filterHeaders(array $headers): array
+    {
+        return array_diff_key($headers, array_flip(self::SENSITIVE_HEADERS));
+    }
+}

--- a/src/Http/TracedResponse.php
+++ b/src/Http/TracedResponse.php
@@ -51,29 +51,6 @@ class TracedResponse implements ResponseInterface, StreamableInterface
         return $this->response->getHeaders($throw);
     }
 
-    private function toReadableHeaderValue(mixed $value): string
-    {
-        if (null === $value) {
-            return 'null';
-        } elseif (\is_array($value)) {
-            return implode(', ', array_map([$this, __FUNCTION__], $value));
-        } elseif (\is_scalar($value)) {
-            if (\is_bool($value)) {
-                return true === $value ? 'true' : 'false';
-            }
-
-            return (string) $value;
-        } elseif (\is_object($value)) {
-            if (method_exists($value, '__toString')) {
-                return (string) $value;
-            }
-
-            return '(object)#'.$value::class;
-        }
-
-        return \gettype($value);
-    }
-
     public function getContent(bool $throw = true): string
     {
         try {

--- a/src/Http/TracedResponse.php
+++ b/src/Http/TracedResponse.php
@@ -182,13 +182,7 @@ class TracedResponse implements ResponseInterface, StreamableInterface
 
         try {
             if (\in_array('response.headers', $info['user_data']['span_attributes'] ?? [])) {
-                $headers = [];
-                $raw = $this->getHeaders(false);
-                foreach ($raw as $header => $value) {
-                    $headers[$header] = $this->toReadableHeaderValue($value);
-                }
-
-                $this->span->setAttribute('response.headers', $headers);
+                $this->span->setAttribute('response.headers', HttpMessageHelper::formatHeadersForSpanAttribute($this->getHeaders(false)));
             }
 
             if (\in_array('response.body', $info['user_data']['span_attributes'] ?? [])) {

--- a/src/Http/TracingHttpClient.php
+++ b/src/Http/TracingHttpClient.php
@@ -93,6 +93,9 @@ final class TracingHttpClient implements HttpClientInterface
             if (\in_array('request.body', $options['user_data']['span_attributes'])) {
                 $attributes['request.body'] = self::getRequestBody($options);
             }
+            if (\in_array('request.headers', $options['user_data']['span_attributes'])) {
+                $attributes['request.headers'] = HttpMessageHelper::formatHeadersForSpanAttribute($headers);
+            }
         } catch (\Throwable) {
         }
 

--- a/src/Semantics/Attribute/ClientRequestAttributeProvider.php
+++ b/src/Semantics/Attribute/ClientRequestAttributeProvider.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Semantics\Attribute;
 
+use Instrumentation\Http\HttpSensitiveDataHelper;
 use OpenTelemetry\SemConv\TraceAttributes;
 
 class ClientRequestAttributeProvider implements ClientRequestAttributeProviderInterface
@@ -24,7 +25,7 @@ class ClientRequestAttributeProvider implements ClientRequestAttributeProviderIn
     {
         $attributes = [
             TraceAttributes::HTTP_METHOD => strtoupper($method),
-            TraceAttributes::HTTP_URL => $url,
+            TraceAttributes::HTTP_URL => HttpSensitiveDataHelper::filterUrl($url),
         ];
 
         foreach ($this->capturedHeaders as $header) {


### PR DESCRIPTION
Before (the header names are missing, only the values are displayed) :
<img width="686" alt="Capture d’écran 2023-04-07 à 15 46 07" src="https://user-images.githubusercontent.com/3588995/230619908-cc296293-9c9b-4b18-ab8f-f4092b007ea7.png">

After : 
<img width="826" alt="Capture d’écran 2023-04-07 à 15 35 13" src="https://user-images.githubusercontent.com/3588995/230619921-de403daa-aff5-4071-99cc-de377f1fefc4.png">
