### PR TITLE
chore: remove Symfony 6.3 deprecation messages

### DIFF
--- a/spec/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriberSpec.php
+++ b/spec/Tracing/Instrumentation/EventSubscriber/CommandEventSubscriberSpec.php
@@ -141,12 +141,12 @@ class CommandEventSubscriberSpec extends ObjectBehavior
         $span->end()->shouldNotHaveBeenCalled();
     }
 
-    private function createConsoleCommandEvent(Command|null $command = null): ConsoleCommandEvent
+    private function createConsoleCommandEvent(Command $command = null): ConsoleCommandEvent
     {
         return new ConsoleCommandEvent($command, new ArrayInput([]), new NullOutput());
     }
 
-    private function createConsoleErrorEvent(Command|null $command = null): ConsoleErrorEvent
+    private function createConsoleErrorEvent(Command $command = null): ConsoleErrorEvent
     {
         return new ConsoleErrorEvent(new ArrayInput([]), new NullOutput(), new \Exception());
     }

--- a/spec/Tracing/Propagation/Messenger/TraceContextStampSpec.php
+++ b/spec/Tracing/Propagation/Messenger/TraceContextStampSpec.php
@@ -10,6 +10,7 @@ namespace spec\Instrumentation\Tracing\Propagation\Messenger;
 use Instrumentation\Tracing\Propagation\Exception\ContextPropagationException;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\TraceFlags;
 use OpenTelemetry\API\Trace\TraceState;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Messenger\Stamp\StampInterface;
@@ -48,7 +49,7 @@ class TraceContextStampSpec extends ObjectBehavior
         $span = new NonRecordingSpan(SpanContext::create(
             'b23f37322b169de7bcaf63b9f84b1427',
             '3c17130d40834256',
-            SpanContext::TRACE_FLAG_DEFAULT,
+            TraceFlags::DEFAULT,
             (new TraceState())->with('key', 'value'),
         ));
         $scope = $span->activate();

--- a/src/Http/TracingHttpClient.php
+++ b/src/Http/TracingHttpClient.php
@@ -37,7 +37,7 @@ final class TracingHttpClient implements HttpClientInterface
      * @param HttpClientInterface|array<mixed>|null $client
      */
     public function __construct(
-        HttpClientInterface|array|null $client = null,
+        HttpClientInterface|array $client = null,
         ClientRequestOperationNameResolverInterface $operationNameResolver = null,
         ClientRequestAttributeProviderInterface $attributeProvider = null,
         int $maxHostConnections = 6,

--- a/src/InstrumentationBundle.php
+++ b/src/InstrumentationBundle.php
@@ -22,6 +22,10 @@ class InstrumentationBundle extends Bundle
 
     public function boot(): void
     {
+        if (null === $this->container) {
+            return;
+        }
+
         $this->container->get(Logging\Logging::class);
 
         /** @var TracerProviderInterface $tracerProvider */

--- a/src/Logging/Logging.php
+++ b/src/Logging/Logging.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Instrumentation\Logging;
 
-use OpenTelemetry\API\Common\Log\LoggerHolder;
+use OpenTelemetry\API\LoggerHolder;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 

--- a/src/Semantics/Attribute/ServerRequestAttributeProviderInterface.php
+++ b/src/Semantics/Attribute/ServerRequestAttributeProviderInterface.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 interface ServerRequestAttributeProviderInterface
 {
     /**
-     * @return array<string|TraceAttributes::*,string|array<string>>
+     * @return array<non-empty-string|TraceAttributes::*,string|array<string>>
      */
     public function getAttributes(Request $request): array;
 }

--- a/src/Semantics/OperationName/RoutePath/RouteCacheWarmer.php
+++ b/src/Semantics/OperationName/RoutePath/RouteCacheWarmer.php
@@ -18,12 +18,12 @@ class RouteCacheWarmer implements CacheWarmerInterface
     {
     }
 
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }
 
-    public function warmUp(string $cacheDir)
+    public function warmUp(string $cacheDir): array
     {
         $routes = [];
         foreach ($this->router->getRouteCollection() as $name => $route) {

--- a/src/Tracing/Propagation/EventSubscriber/MessengerEventSubscriber.php
+++ b/src/Tracing/Propagation/EventSubscriber/MessengerEventSubscriber.php
@@ -23,7 +23,7 @@ class MessengerEventSubscriber implements EventSubscriberInterface
     private LoggerInterface $logger;
     private ?ScopeInterface $scope = null;
 
-    public function __construct(LoggerInterface|null $logger = null)
+    public function __construct(LoggerInterface $logger = null)
     {
         $this->logger = $logger ?? new NullLogger();
     }


### PR DESCRIPTION
- `RouteCacheWarmer` : 
  - Add return types
- `ErrorNormalizer`: 
  - Remove deprecated interface `CacheableSupportsMethodInterface`, use method `getSupportedTypes()` instead.
  - Implement `SerializerAwareInterface`.
- Apply phpstan/php-cs-fixer recommendations