### PR TITLE
fix(Tracing): end tracing after calling TracedResponse::toStream()

### DIFF
--- a/src/Tracing/Propagation/Doctrine/DBAL/Connection.php
+++ b/src/Tracing/Propagation/Doctrine/DBAL/Connection.php
@@ -24,7 +24,7 @@ final class Connection implements ServerInfoAwareConnection
 
     public function prepare(string $sql): Statement
     {
-        $sql = $sql.self::formatComments($this->infoProvider->getTraceContext());
+        $sql .= self::formatComments($this->infoProvider->getTraceContext());
 
         return $this->decorated->prepare($sql);
     }

--- a/src/Tracing/Serializer/Normalizer/ErrorNormalizer.php
+++ b/src/Tracing/Serializer/Normalizer/ErrorNormalizer.php
@@ -22,7 +22,7 @@ class ErrorNormalizer implements NormalizerInterface, SerializerAwareInterface
     {
     }
 
-    public function setSerializer(SerializerInterface $serializer)
+    public function setSerializer(SerializerInterface $serializer): void
     {
         if ($this->decorated instanceof SerializerAwareInterface) {
             $this->decorated->setSerializer($serializer);


### PR DESCRIPTION
We were not ending the span when using the method `toStream()`. So the span was ended by the method `__destruct()` without adding the response content to the span attributes.

In the method `TracedResponse::toStream()` :
- The stream is stored in a private variable to be reused later (just like content)
- `endTracing()` is called at the end of the method

In the method `TracedResponse::endTracing()` :
- The stream is converted to string and added to the span as `response.body` attribute