### PR TITLE
chore: freeze open-telemetry/sdk and open-telemetry/api version to avoid breaking changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,7 @@
     "monolog/monolog": "^2.0",
     "nyholm/dsn": "^2.0",
     "nyholm/psr7": "^1.5",
-    "open-telemetry/sdk": "^1.0.1",
-    "open-telemetry/api": "^1.0.1",
-    "open-telemetry/context": "^1.0@dev",
-    "open-telemetry/sem-conv": "^1.0@dev",
+    "open-telemetry/sdk": "1.0.4",
     "promphp/prometheus_client_php": "^2.4",
     "psr/http-client": "^1.0",
     "symfony/dependency-injection": "*"


### PR DESCRIPTION
As the [opentelemetry PGP implementation](https://github.com/opentelemetry-php/sdk) does not respect semver and often breaks backward compatibility, I propose to freeze the version of the "open-telemetry/sdk" package