### PR TITLE
feat(Tracing): Allow to specify extra attributes on http calls

### DIFF
--- a/src/Http/TracingHttpClient.php
+++ b/src/Http/TracingHttpClient.php
@@ -77,7 +77,15 @@ final class TracingHttpClient implements HttpClientInterface
     }
 
     /**
-     * @param array<mixed> $options
+     * @param array{
+     *     on_progress?: ?callable,
+     *     headers?: array<string,array<string>>,
+     *     extra?: array{
+     *         operation_name: non-empty-string,
+     *         span_attributes: array<non-empty-string>,
+     *         extra_attributes: array<non-empty-string, string>
+     *     }
+     * } $options
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
@@ -86,8 +94,9 @@ final class TracingHttpClient implements HttpClientInterface
         $operationName = $options['extra']['operation_name'] ?? $this->operationNameResolver->getOperationName($method, $url);
 
         $attributes = $this->attributeProvider->getAttributes($method, $url, $headers);
+        $attributes += $options['extra']['extra_attributes'] ?? [];
 
-        $options['user_data']['span_attributes'] = $this->getExtraSpanAttributes($options['extra']['operation_name'] ?? null);
+        $options['user_data']['span_attributes'] = $this->getExtraSpanAttributes($options['extra']['span_attributes'] ?? null);
 
         try {
             if (\in_array('request.body', $options['user_data']['span_attributes'])) {


### PR DESCRIPTION
Usage example
1. To manage request span attributes:
_The main purpose is to hide request body/attributes from the attributes_
```php
$options = [
    'extra' => [
        'span_attributes' => ['request.headers'] // supported "request.headers" and "request.body", both are activated by default
    ]
]

$this->client->request('get', 'https://example.com/spmething', $options);
```

2. to add extra attributes to the span:
_The main purpose is to add service specific attributes and help the otel-collector to map data_
```php
$options = [
    'extra' => [
        'extra_attributes' => ['endpoint' => 'services', 'adapter' => 'foo']
    ]
]

$this->client->request('get', 'https://example.com/spmething', $options);
```

3. To specify trace name
_This name will be name of the trace on jaeger. If not specified it will be method and url. Ex: http api.demo.distribusion.com_
```php
$options = [
    'extra' => [
        'operation_name' => 'trains.distribusion.services'
    ]
]

$this->client->request('get', 'https://example.com/spmething', $options);
```