### PR TITLE
chore: data collector independent of opentelemetry sdk

### DIFF
--- a/src/Tracing/Bridge/Profiler/DataCollector/TraceContextDataCollector.php
+++ b/src/Tracing/Bridge/Profiler/DataCollector/TraceContextDataCollector.php
@@ -92,6 +92,6 @@ class TraceContextDataCollector extends AbstractDataCollector
 
     public static function getTemplate(): string|null
     {
-        return '@InstrumentationDataCollector/collector.html.twig';
+        return '@Instrumentation/collector.html.twig';
     }
 }

--- a/src/Tracing/Bridge/Profiler/Templates/collector.html.twig
+++ b/src/Tracing/Bridge/Profiler/Templates/collector.html.twig
@@ -6,11 +6,11 @@
     {% endset %}
 
     {% set text %}
-        {% if collector.instrumentationScope %}
+        {% if collector.instrumentationScopeName %}
             <div class="sf-toolbar-info-group">
                 <div class="sf-toolbar-info-piece">
                     <b>Scope</b>
-                    <span>{{ collector.instrumentationScope.name }}</span>
+                    <span>{{ collector.instrumentationScopeName }}</span>
                 </div>
             </div>
         {% endif %}
@@ -27,7 +27,7 @@
         <div class="sf-toolbar-info-group">
             <div class="sf-toolbar-info-piece">
                 <b>Sampled</b>
-                {% if collector.rootSpan.context.sampled %}
+                {% if collector.rootSpanContext.isSampled %}
                     <span class="sf-toolbar-status sf-toolbar-status-green">yes</span>
                 {% else %}
                     <span class="sf-toolbar-status sf-toolbar-status-red">no</span>
@@ -35,7 +35,7 @@
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Valid</b>
-                {% if collector.rootSpan.context.valid %}
+                {% if collector.rootSpanContext.isValid %}
                     <span class="sf-toolbar-status sf-toolbar-status-green">yes</span>
                 {% else %}
                     <span class="sf-toolbar-status sf-toolbar-status-red">no</span>
@@ -43,7 +43,7 @@
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Remote</b>
-                {% if collector.rootSpan.context.remote %}
+                {% if collector.rootSpanContext.isRemote %}
                     <span class="sf-toolbar-status">yes</span>
                 {% else %}
                     <span class="sf-toolbar-status">no</span>


### PR DESCRIPTION
We discovered an issue on a project using Guzzle as HTTP client.  
Guzzle client is using `Closure`, since the collector is putting all the span in the `data` attribute and the `span` contains the exporter, which contains the transport (Guzzle client): we had an error when the parent class try to serialize `data`.

To avoid any error in the future, this PR propose to build the `data` as a "view model" for the Twig template.  
By making sure we only provide the scalar values we want to expose in the template, we remove the unknown behavior of serializing objects from OpenTelemetry/SDK

---
Blocked until https://github.com/worldia/instrumentation-bundle/pull/70 is merged