### PR TITLE
make the package more findable on packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
   "name": "worldia/instrumentation-bundle",
+  "description": "Symfony opentelemetry auto-instrumentation: requests, commands, messenger, doctrine.",
   "type": "symfony-bundle",
   "license": "MIT",
   "keywords": [
     "instrumentation",
     "tracing",
     "metrics",
+    "symfony",
+    "opentelemetry",
+    "otel",
     "open-telemetry",
     "prometheus"
   ],


### PR DESCRIPTION
Example: missing from this search https://packagist.org/search/?q=symfony+instrumentation 
This bundle deserves to be seen.