### PR TITLE
feat: add support for dbal 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "symfony/dependency-injection": "*"
   },
   "require-dev": {
-    "doctrine/dbal": "4.3.3",
+    "doctrine/dbal": "^4.0",
     "open-telemetry/gen-otlp-protobuf": "^1.0",
     "phpstan/phpstan": "^1.4",
     "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "symfony/dependency-injection": "*"
   },
   "require-dev": {
-    "doctrine/dbal": "^3.0",
+    "doctrine/dbal": "4.3.3",
     "open-telemetry/gen-otlp-protobuf": "^1.0",
     "phpstan/phpstan": "^1.4",
     "phpunit/phpunit": "^10.5",

--- a/src/Semantics/Attribute/DoctrineConnectionAttributeProvider.php
+++ b/src/Semantics/Attribute/DoctrineConnectionAttributeProvider.php
@@ -11,38 +11,40 @@ namespace Instrumentation\Semantics\Attribute;
 
 use Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use OpenTelemetry\SemConv\TraceAttributes;
+use OpenTelemetry\SemConv\Attributes\DbAttributes;
+use OpenTelemetry\SemConv\Attributes\NetworkAttributes;
+use OpenTelemetry\SemConv\Attributes\ServerAttributes;
 
 class DoctrineConnectionAttributeProvider implements DoctrineConnectionAttributeProviderInterface
 {
     public function getAttributes(AbstractPlatform $platform, array $params): array
     {
-        $attributes = [TraceAttributes::DB_SYSTEM => $this->getSystemAttribute($platform)];
+        $attributes = [DbAttributes::DB_SYSTEM_NAME => $this->getSystemAttribute($platform)];
 
         if (isset($params['user'])) {
             $attributes['db.user'] = $params['user'];
         }
 
         if (isset($params['dbname'])) {
-            $attributes[TraceAttributes::DB_NAMESPACE] = $params['dbname'];
+            $attributes[DbAttributes::DB_NAMESPACE] = $params['dbname'];
         }
 
         if (isset($params['host']) && !empty($params['host']) && !isset($params['memory'])) {
             if (false === filter_var($params['host'], \FILTER_VALIDATE_IP)) {
-                $attributes[TraceAttributes::SERVER_ADDRESS] = $params['host'];
+                $attributes[ServerAttributes::SERVER_ADDRESS] = $params['host'];
             } else {
-                $attributes[TraceAttributes::NETWORK_PEER_ADDRESS] = $params['host'];
+                $attributes[NetworkAttributes::NETWORK_PEER_ADDRESS] = $params['host'];
             }
         }
 
         if (isset($params['port'])) {
-            $attributes[TraceAttributes::SERVER_PORT] = (string) $params['port'];
+            $attributes[ServerAttributes::SERVER_PORT] = (string) $params['port'];
         }
 
         if (isset($params['unix_socket'])) {
-            $attributes[TraceAttributes::NETWORK_TRANSPORT] = 'unix';
+            $attributes[NetworkAttributes::NETWORK_TRANSPORT] = 'unix';
         } elseif (isset($params['memory'])) {
-            $attributes[TraceAttributes::NETWORK_TRANSPORT] = 'inproc';
+            $attributes[NetworkAttributes::NETWORK_TRANSPORT] = 'inproc';
         }
 
         return $attributes;
@@ -62,7 +64,7 @@ class DoctrineConnectionAttributeProvider implements DoctrineConnectionAttribute
         if ($platform instanceof Platforms\SQLServerPlatform) {
             return 'mssql';
         }
-        if ($platform instanceof Platforms\SqlitePlatform) {
+        if ($platform instanceof Platforms\SQLitePlatform) {
             return 'sqlite';
         }
         if ($platform instanceof Platforms\OraclePlatform) {

--- a/src/Semantics/Attribute/DoctrineConnectionAttributeProviderInterface.php
+++ b/src/Semantics/Attribute/DoctrineConnectionAttributeProviderInterface.php
@@ -17,7 +17,7 @@ interface DoctrineConnectionAttributeProviderInterface
      * @param array<string,mixed> $connectionParams
      *
      * @return array{
-     *           'db.system':string,
+     *           'db.system.name':string,
      *           'db.user'?:string,
      *           'db.name'?:string,
      *           'net.peer.name'?:string,

--- a/src/Tracing/Doctrine/Instrumentation/DBAL/Statement.php
+++ b/src/Tracing/Doctrine/Instrumentation/DBAL/Statement.php
@@ -30,17 +30,12 @@ class Statement implements DoctrineStatement
     {
     }
 
-    public function bindValue($param, $value, $type = ParameterType::STRING): bool
+    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
     {
-        return $this->decoratedStatement->bindValue($param, $value, $type);
+        $this->decoratedStatement->bindValue($param, $value, $type);
     }
 
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
-    {
-        return $this->decoratedStatement->bindParam($param, $variable, $type, ...\array_slice(\func_get_args(), 3));
-    }
-
-    public function execute($params = null): Result
+    public function execute(): Result
     {
         $span = $this->getTracer()
             ->spanBuilder(self::OP_STMT_EXECUTE)
@@ -54,7 +49,7 @@ class Statement implements DoctrineStatement
         }
 
         try {
-            return $this->decoratedStatement->execute($params);
+            return $this->decoratedStatement->execute();
         } finally {
             $span->end();
         }

--- a/src/Tracing/Doctrine/Propagation/DBAL/Connection.php
+++ b/src/Tracing/Doctrine/Propagation/DBAL/Connection.php
@@ -11,9 +11,7 @@ namespace Instrumentation\Tracing\Doctrine\Propagation\DBAL;
 
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement;
-use Doctrine\DBAL\ParameterType;
 use Instrumentation\Tracing\Doctrine\Propagation\TraceContextInfoProviderInterface;
 
 final class Connection implements ConnectionInterface
@@ -34,47 +32,43 @@ final class Connection implements ConnectionInterface
         return $this->decorated->query($sql);
     }
 
-    public function quote($value, $type = ParameterType::STRING): mixed
+    public function quote(string $value): string
     {
-        return $this->decorated->quote($value, $type);
+        return $this->decorated->quote($value);
     }
 
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         return $this->decorated->exec($sql);
     }
 
-    public function lastInsertId($name = null): string|int|false
+    public function lastInsertId(): string|int
     {
-        return $this->decorated->lastInsertId($name);
+        return $this->decorated->lastInsertId();
     }
 
-    public function beginTransaction(): bool
+    public function beginTransaction(): void
     {
-        return $this->decorated->beginTransaction();
+        $this->decorated->beginTransaction();
     }
 
-    public function commit(): bool
+    public function commit(): void
     {
-        return $this->decorated->commit();
+        $this->decorated->commit();
     }
 
-    public function rollBack(): bool
+    public function rollBack(): void
     {
-        return $this->decorated->rollBack();
+        $this->decorated->rollBack();
     }
 
     public function getServerVersion(): string
     {
-        if ($this->decorated instanceof ServerInfoAwareConnection) {
-            return $this->decorated->getServerVersion();
-        }
-
-        return 'unknown';
+        return $this->decorated->getServerVersion();
     }
 
     /**
-     * @return \PDO|object|resource
+     * @return object|resource
      */
     public function getNativeConnection()
     {

--- a/src/Tracing/Doctrine/Propagation/DBAL/Driver.php
+++ b/src/Tracing/Doctrine/Propagation/DBAL/Driver.php
@@ -9,13 +9,11 @@ declare(strict_types=1);
 
 namespace Instrumentation\Tracing\Doctrine\Propagation\DBAL;
 
-use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Doctrine\DBAL\VersionAwarePlatformDriver;
+use Doctrine\DBAL\ServerVersionProvider;
 use Instrumentation\Tracing\Doctrine\Propagation\TraceContextInfoProviderInterface;
 
 final class Driver implements DriverInterface
@@ -29,34 +27,13 @@ final class Driver implements DriverInterface
         return new Connection($this->decorated->connect($params), $this->infoProvider);
     }
 
-    public function getDatabasePlatform(): AbstractPlatform
+    public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
     {
-        return $this->decorated->getDatabasePlatform();
-    }
-
-    /**
-     * @phpstan-template T of AbstractPlatform
-     *
-     * @phpstan-param T $platform
-     *
-     * @phpstan-return AbstractSchemaManager<T>
-     */
-    public function getSchemaManager(DBALConnection $conn, AbstractPlatform $platform): AbstractSchemaManager
-    {
-        return $this->decorated->getSchemaManager($conn, $platform);
+        return $this->decorated->getDatabasePlatform($versionProvider);
     }
 
     public function getExceptionConverter(): ExceptionConverter
     {
         return $this->decorated->getExceptionConverter();
-    }
-
-    public function createDatabasePlatformForVersion(string $version): AbstractPlatform
-    {
-        if ($this->decorated instanceof VersionAwarePlatformDriver) {
-            return $this->decorated->createDatabasePlatformForVersion($version);
-        }
-
-        return $this->decorated->getDatabasePlatform();
     }
 }

--- a/tests/Semantics/Attribute/DoctrineConnectionAttributeProviderTest.php
+++ b/tests/Semantics/Attribute/DoctrineConnectionAttributeProviderTest.php
@@ -30,12 +30,12 @@ class DoctrineConnectionAttributeProviderTest extends TestCase
             Platforms\PostgreSQLPlatform::class => 'postgresql',
             Platforms\AbstractMySQLPlatform::class => 'mysql',
             Platforms\SQLServerPlatform::class => 'mssql',
-            Platforms\SqlitePlatform::class => 'sqlite',
+            Platforms\SQLitePlatform::class => 'sqlite',
             Platforms\OraclePlatform::class => 'oracle',
             Platforms\DB2Platform::class => 'db2',
         ] as $class => $name) {
             $attributes = $provider->getAttributes($this->createMock($class), []);
-            $this->assertEquals($name, $attributes['db.system']);
+            $this->assertEquals($name, $attributes['db.system.name']);
         }
     }
 


### PR DESCRIPTION
Added support for dbal 4, that should fix https://github.com/worldia/instrumentation-bundle/issues/79

As it's a breaking change, it probably should go in version 3 of instrumentation-bundle 🤔

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Doctrine DBAL instrumentation/propagation to DBAL 4 APIs and switch DB attributes to new semconv keys.
> 
> - **Doctrine DBAL (Instrumentation & Propagation)**:
>   - Adjust method signatures to DBAL 4 (`quote`, `exec`, `lastInsertId`, `beginTransaction`/`commit`/`rollBack` now `void`).
>   - Add `getServerVersion()` passthrough; refine `getNativeConnection()` return phpdoc.
>   - Update drivers to DBAL 4 platform API: use `ServerVersionProvider` and `StaticServerVersionProvider`; remove legacy schema-related methods.
> - **Semantics**:
>   - Replace `TraceAttributes` with `DbAttributes`/`NetworkAttributes`/`ServerAttributes` and migrate keys (e.g., `db.system.name`, `db.namespace`).
>   - Update platform class references (`SQLitePlatform`).
> - **Tests**: Align expectations with new attribute keys and platform class.
> - **Composer**: Bump `doctrine/dbal` dev requirement to `^4.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9a7277ee64a660dd56d5911f1301adceaa86274. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->