### PR TITLE
fix: use doctrine version aware drivers

### DIFF
--- a/src/Tracing/Doctrine/Instrumentation/DBAL/Driver.php
+++ b/src/Tracing/Doctrine/Instrumentation/DBAL/Driver.php
@@ -20,7 +20,7 @@ use Instrumentation\Semantics\Attribute\DoctrineConnectionAttributeProviderInter
 use Instrumentation\Tracing\Bridge\MainSpanContextInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 
-final class Driver implements DriverInterface
+final class Driver implements VersionAwarePlatformDriver
 {
     public function __construct(private TracerProviderInterface $tracerProvider, private DoctrineConnectionAttributeProviderInterface $attributeProvider, private DriverInterface $decorated, private MainSpanContextInterface $mainSpanContext, private bool $logQueries)
     {
@@ -55,7 +55,7 @@ final class Driver implements DriverInterface
         return $this->decorated->getExceptionConverter();
     }
 
-    public function createDatabasePlatformForVersion(string $version): AbstractPlatform
+    public function createDatabasePlatformForVersion($version): AbstractPlatform
     {
         if ($this->decorated instanceof VersionAwarePlatformDriver) {
             return $this->decorated->createDatabasePlatformForVersion($version);

--- a/src/Tracing/Doctrine/Propagation/DBAL/Driver.php
+++ b/src/Tracing/Doctrine/Propagation/DBAL/Driver.php
@@ -18,7 +18,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 use Instrumentation\Tracing\Doctrine\Propagation\TraceContextInfoProviderInterface;
 
-final class Driver implements DriverInterface
+final class Driver implements VersionAwarePlatformDriver
 {
     public function __construct(private DriverInterface $decorated, private TraceContextInfoProviderInterface $infoProvider)
     {
@@ -51,7 +51,7 @@ final class Driver implements DriverInterface
         return $this->decorated->getExceptionConverter();
     }
 
-    public function createDatabasePlatformForVersion(string $version): AbstractPlatform
+    public function createDatabasePlatformForVersion($version): AbstractPlatform
     {
         if ($this->decorated instanceof VersionAwarePlatformDriver) {
             return $this->decorated->createDatabasePlatformForVersion($version);


### PR DESCRIPTION
When the drivers don't implement this interface, Doctrine is not able to know that it can create the platform for a specific version. It seems to fallback to using the default platform.   For instance, with MySQL, the "json" type is not handled in all versions, the generic driver doesn't handle it.  
Not using a driver aware of the version generates error when using CLI commands for doctrine: <img width="1339" height="405" alt="image" src="https://github.com/user-attachments/assets/34110d57-831c-4f7b-97aa-8c37009e4cdd" />
