### PR TITLE
fix: end http client trace without blocking on timeout

### DIFF
--- a/src/Tracing/HttpClient/TracingHttpClient.php
+++ b/src/Tracing/HttpClient/TracingHttpClient.php
@@ -80,6 +80,7 @@ final class TracingHttpClient implements HttpClientInterface
             ->spanBuilder($operationName)
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->startSpan();
+        $options['user_data']['span'] = $span;
 
         $scope = $span->activate();
 


### PR DESCRIPTION
The current implementation to call the `on_response` callback is not asynchronous and causes issues when we want to stop a request, i.e.: timeout

Fixing it is not trivial because we are currently calling the callback when closing the trace, where we don't know the situation of the response: completed, cancelled, timeout, etc.

Those `on_request` and `on_response` callbacks seems like additional responsibilities we should try to get rid of.  
Preparing to move in this direction, this PR add the span to the response through the `user_data` information.  
This way any client can access it and decide when to do what they need to do.

To showcase this, I used an example where I forced a request to take more than 10s while using a timeout of 5s.  
Before:  
We see that while the first request timeout after 5s, we don't start the 2nd before ~10s.  
This is the time we wait to get the headers.  
We don't wait for the full response because the "on_response" callback doesn't read the stream.
<img width="1638" height="521" alt="image" src="https://github.com/user-attachments/assets/2fcf626a-9464-42da-80f9-28e23254ebe3" />  
After:  
Here we can see that the next request start right after the timeout (minus a little delay from the retry config).
<img width="1643" height="561" alt="image" src="https://github.com/user-attachments/assets/12f5f219-2639-4031-9ecb-518fcb60ebd6" />
  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Attach the created client span to `options['user_data']['span']` in `TracingHttpClient::request` so it’s accessible downstream (e.g., response handling).
> 
> - **Tracing**
>   - `src/Tracing/HttpClient/TracingHttpClient.php`
>     - In `request()`, after starting the client span, store it in `options['user_data']['span']` to make the span accessible to downstream handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be7ca05bc7a026512bac8e1a0608ecceb963b006. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->