### PR TITLE
chore: add repository Claude skills for instrumentation patterns

### DIFF
--- a/.claude/skills/add-metric/SKILL.md
+++ b/.claude/skills/add-metric/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: add-metric
+description: Add a new OpenTelemetry metric (counter, up-down counter, histogram, or gauge) to this bundle. Use when asked to "add a metric", "count X", "record a histogram for X", or "publish token/usage metrics" in worldia/instrumentation-bundle. Encodes the metrics conventions, which differ from tracing — DI-only meter (no static facade), hardcoded attribute strings, and a separate feature toggle/subscriber.
+---
+
+# Add a metric
+
+Metrics in this bundle are wired separately from tracing and follow different rules. Do not bolt metrics onto a tracing decorator/subscriber — even when both observe the same event, the bundle keeps them as independent subscribers under independent toggles (see Messenger: `src/Tracing/Messenger/...` vs `src/Metrics/EventSubscriber/MessageEventSubscriber.php`).
+
+## Key differences from tracing
+
+- **No static facade.** There is no `Metrics::getMeter()` equivalent to `Tracing::getTracer()`. Inject `OpenTelemetry\API\Metrics\MeterProviderInterface` and call `$meterProvider->getMeter('instrumentation')` in the constructor.
+- **Attribute names are plain strings** (e.g. `['bus' => ..., 'class' => ...]`), not `OpenTelemetry\SemConv` constants. (Tracing uses semconv constants; metrics historically don't.) If a published semconv _metric_ exists for your case (e.g. `gen_ai.client.token.usage`), prefer that instrument name and its semconv attributes for ecosystem compatibility, but match the surrounding code's style.
+
+## Instrument types & naming
+
+Create instruments on the meter and act on them:
+
+- `createCounter('<name>_total')->add($n, $attrs)` — monotonic.
+- `createUpDownCounter('<name>')->add(±1, $attrs)` — gauge-like running count (e.g. `consumers_active`, `messages_handling`).
+- `createHistogram('<name>_<unit>', '<unit>', '<desc>')->record($v, $attrs)` — distributions (e.g. `messages_time_to_consume_seconds`).
+- `createGauge('<name>_<unit>', null, '<desc>')->record($v, $attrs)` — point-in-time (e.g. `memory_usage_bytes`).
+
+Naming: snake_case, unit suffix (`_seconds`, `_bytes`), `_total` suffix for monotonic counters. Reference: `src/Metrics/EventSubscriber/MessageEventSubscriber.php`, `ConsumerEventSubscriber.php`, `RequestEventSubscriber.php`.
+
+## The subscriber
+
+Add `src/Metrics/EventSubscriber/<Feature>EventSubscriber.php` implementing `EventSubscriberInterface`, with `MeterProviderInterface` injected. Cache the meter in the constructor; create instruments lazily where recorded (the existing code calls `createCounter(...)` at the record site — that's fine, instruments are idempotent by name).
+
+## DI wiring
+
+- **`src/DependencyInjection/config/metrics/<feature>.php`** — register the subscriber with `->autoconfigure()` and `->args([service(MeterProviderInterface::class)])`. Model: `config/metrics/message.php`.
+- **`src/DependencyInjection/Configuration.php`** — add `arrayNode('<feature>')->addDefaultsIfNotSet()` under `metrics`, with `booleanNode('enabled')->defaultFalse()` and any `blacklist` node (see the `metrics` tree, lines 180–205).
+- **`src/DependencyInjection/Extension.php` → `loadMetrics()`** — add `if ($this->isConfigEnabled($container, $config['<feature>'])) { ...; $loader->load('<feature>.php'); }`. Set `metrics.<feature>.blacklist` param first if the subscriber filters (model: the `request` branch, lines 230–233). The core `metrics.php` (MeterProvider) is always loaded.
+
+## Verify
+
+- Subscriber gets the meter from injected `MeterProviderInterface`, never a static accessor.
+- Instrument name follows snake_case + unit/`_total` convention.
+- Feature is opt-in via its own `metrics.<feature>.enabled` node and loaded in `loadMetrics()`.
+- Add/extend a test under `tests/Metrics/` using an in-memory metric reader, mirroring existing metric tests.

--- a/.claude/skills/add-tracing-instrumentation/SKILL.md
+++ b/.claude/skills/add-tracing-instrumentation/SKILL.md
@@ -10,7 +10,11 @@ Every tracing instrumentation in this bundle is built from the same five parts. 
 ## Pick the seam first
 
 - **Decorator** when the thing you trace is a service with an interface you can wrap, and the span must outlive the call (async/deferred result). Models: `src/Tracing/HttpClient/TracingHttpClient.php`, `src/Tracing/Doctrine/`. For deferred results, **end the span when the result is consumed AND add a `__destruct()` backstop that ends it if it never is** — see `TracedResponse` (`src/Tracing/HttpClient/TracedResponse.php`). A span that only ends in a downstream callback leaks.
-- **EventSubscriber** when there's a Symfony event marking start/end. Models: Request, Command, Messenger (`src/Tracing/Messenger/EventListener/MessageEventSubscriber.php`). Get the tracer via `service(TracerProviderInterface::class)`, not a static facade, in the listener.
+- **EventSubscriber** when there's a Symfony event marking start/end. Models: Request, Command, Messenger (`src/Tracing/Messenger/EventListener/MessageEventSubscriber.php`).
+
+### Get the tracer by injection, never the static facade
+
+Inside the bundle, **inject `OpenTelemetry\API\Trace\TracerProviderInterface` via the constructor and use `TracerAwareTrait`'s `getTracer()`** (the trait declares the `$tracerProvider` property; assign the constructor arg to it). Do **not** call `Instrumentation\Tracing\Tracing::getTracer()` from bundle code — that static facade exists for _application_ code outside the bundle, where DI isn't convenient. Every in-bundle listener/decorator (e.g. `MessageEventSubscriber`, `TracingAgent`) injects the provider. For decorators built in a compiler pass, add `new Reference(TracerProviderInterface::class)` to the decorator's arguments.
 
 ## The five parts
 

--- a/.claude/skills/add-tracing-instrumentation/SKILL.md
+++ b/.claude/skills/add-tracing-instrumentation/SKILL.md
@@ -34,9 +34,18 @@ If users should be able to exclude items, add a Voter extending `AbstractVoter` 
 
 ### 5. DI wiring
 
-- **`src/DependencyInjection/config/tracing/<feature>.php`** — register the decorator/subscriber, voter, sampling listener. Inject providers via `service(...)`, config via `param('tracing.<feature>.*')`. Use `->autoconfigure()` on subscribers. Decorators: `->decorate(Interface::class, null, <priority>)` with `service('.inner')` as first arg. Multiple tagged targets → use a compiler pass instead (model: AI platform's `AIPlatformTracingCompilerPass`).
+- **`src/DependencyInjection/config/tracing/<feature>.php`** — register the decorator/subscriber, voter, sampling listener. Inject providers via `service(...)`, config via `param('tracing.<feature>.*')`. Use `->autoconfigure()` on subscribers.
 - **`src/DependencyInjection/Configuration.php`** — add an `arrayNode('<feature>')->addDefaultsIfNotSet()` under `tracing`, with `booleanNode('enabled')` (default `true`, or `false` if it needs an optional dependency) and any `blacklist`/`methods` array nodes. See lines 121–164.
 - **`src/DependencyInjection/Extension.php` → `loadTracing()`** — add `'<feature>'` to the feature loop (`foreach (['request', 'command', 'message', ...] as $feature)`), which loads `<feature>.php` when enabled and copies `blacklist`/`methods` into `tracing.<feature>.*` params. Gate optional-dependency features behind an `interface_exists()`/`class_exists()` check.
+
+#### Choosing the decoration mechanism
+
+This is the bundle's standing convention — follow it, don't introduce a third style:
+
+- **Single, statically-known service id** → decorate declaratively in the `<feature>.php` config: `->decorate(Interface::class, null, <priority>)` with `service('.inner')` as the first arg. This is the _only_ case where compile-time code is not needed. Model: HttpClient (`config/tracing/http.php` decorates `HttpClientInterface`).
+- **Multiple services discovered by tag** (you don't know the ids/count until the app is configured, e.g. `ai.platform`, `ai.agent`, `ai.toolbox`) → you must `findTaggedServiceIds()` and loop, which is only reliable at compile time. Put that loop in a **dedicated `*CompilerPass` class** under `src/DependencyInjection/CompilerPass/`, register an `->abstract()` template service in `<feature>.php`, and invoke the pass from `Extension::process()` gated on `$container->hasDefinition(<TemplateService>::class)`. Models: `AIPlatformTracingCompilerPass`, `AIAgentTracingCompilerPass`, `DoctrineTracingCompilerPass`.
+
+Do **not** inline compile-time container logic directly in `Extension::process()` — all such logic lives in dedicated `*CompilerPass` classes (the Doctrine wiring used to be the lone inline exception and was extracted into `DoctrineTracingCompilerPass`).
 
 ## Verify
 

--- a/.claude/skills/add-tracing-instrumentation/SKILL.md
+++ b/.claude/skills/add-tracing-instrumentation/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: add-tracing-instrumentation
+description: Add a new OpenTelemetry tracing instrumentation to this bundle (a new subsystem to trace, e.g. AI platform, a cache layer, a third-party client). Use when asked to "trace X", "add a span around X", or "instrument X" in worldia/instrumentation-bundle. Encodes the bundle's mandatory cross-cutting conventions: swappable AttributeProvider + OperationNameResolver, blacklist Voter, semconv constants, and the DI wiring across config + Configuration.php + Extension.php.
+---
+
+# Add a tracing instrumentation
+
+Every tracing instrumentation in this bundle is built from the same five parts. Reproduce all five — reviewers reject instrumentations that skip the provider/resolver/voter abstractions or hardcode attribute names.
+
+## Pick the seam first
+
+- **Decorator** when the thing you trace is a service with an interface you can wrap, and the span must outlive the call (async/deferred result). Models: `src/Tracing/HttpClient/TracingHttpClient.php`, `src/Tracing/Doctrine/`. For deferred results, **end the span when the result is consumed AND add a `__destruct()` backstop that ends it if it never is** — see `TracedResponse` (`src/Tracing/HttpClient/TracedResponse.php`). A span that only ends in a downstream callback leaks.
+- **EventSubscriber** when there's a Symfony event marking start/end. Models: Request, Command, Messenger (`src/Tracing/Messenger/EventListener/MessageEventSubscriber.php`). Get the tracer via `service(TracerProviderInterface::class)`, not a static facade, in the listener.
+
+## The five parts
+
+### 1. Semantics — attributes (swappable)
+
+Create `src/Semantics/Attribute/<Feature>AttributeProviderInterface.php` + a default impl. The impl returns `array<non-empty-string, scalar|array>` and **uses `OpenTelemetry\SemConv` constants for every attribute name** — never inline strings like `'gen_ai.system'`. Example: `src/Semantics/Attribute/MessageAttributeProvider.php` uses `MessagingIncubatingAttributes::*`. Custom keys with no semconv equivalent (e.g. `'messenger.bus'`) may be inline.
+
+GenAI/HTTP/DB/etc. constants live in `OpenTelemetry\SemConv\TraceAttributes` (flat) and `OpenTelemetry\SemConv\Attributes\*` / `Incubating\Attributes\*` (split). Grep the installed package before inventing a name.
+
+### 2. Semantics — span name (swappable)
+
+If span naming has any logic, add `src/Semantics/OperationName/<Feature>OperationNameResolverInterface.php` + impl (model: `ClientRequestOperationNameResolver`). Don't hardcode the span name in the decorator/listener.
+
+### 3. Register the semantics services
+
+Add both interfaces to `src/DependencyInjection/config/semconv/semconv.php`, binding interface → default impl with `->set(Interface::class, Impl::class)`. This is the seam that lets users override providers by redefining the service. See lines 50–69 of that file.
+
+### 4. Sampling / blacklist (the bundle's filtering convention)
+
+If users should be able to exclude items, add a Voter extending `AbstractVoter` (`src/Tracing/Bridge/Sampling/Voter/`) implementing only `getOperationNameFromEvent()`, plus its interface. `AbstractVoter` does regex blacklist matching and returns `VOTE_DROP` / `VOTE_ABSTAIN`. Register the voter + a `Sampling\EventListener` in the feature's tracing config (see `config/tracing/message.php` lines 33–43).
+
+### 5. DI wiring
+
+- **`src/DependencyInjection/config/tracing/<feature>.php`** — register the decorator/subscriber, voter, sampling listener. Inject providers via `service(...)`, config via `param('tracing.<feature>.*')`. Use `->autoconfigure()` on subscribers. Decorators: `->decorate(Interface::class, null, <priority>)` with `service('.inner')` as first arg. Multiple tagged targets → use a compiler pass instead (model: AI platform's `AIPlatformTracingCompilerPass`).
+- **`src/DependencyInjection/Configuration.php`** — add an `arrayNode('<feature>')->addDefaultsIfNotSet()` under `tracing`, with `booleanNode('enabled')` (default `true`, or `false` if it needs an optional dependency) and any `blacklist`/`methods` array nodes. See lines 121–164.
+- **`src/DependencyInjection/Extension.php` → `loadTracing()`** — add `'<feature>'` to the feature loop (`foreach (['request', 'command', 'message', ...] as $feature)`), which loads `<feature>.php` when enabled and copies `blacklist`/`methods` into `tracing.<feature>.*` params. Gate optional-dependency features behind an `interface_exists()`/`class_exists()` check.
+
+## Verify
+
+- No attribute-name string literals that have a semconv constant.
+- Provider + resolver are interfaces registered in `semconv.php` and injected (not `new`'d).
+- Deferred-span instrumentations have a destructor backstop.
+- `composer test` / the relevant `tests/Tracing/<Feature>/` test passes; add an `InMemoryExporter`-based test mirroring existing ones.


### PR DESCRIPTION
## What

Adds two repository-scoped Claude skills under `.claude/skills/`, capturing the bundle's cross-cutting instrumentation conventions so future contributions (human or AI-assisted) follow the house patterns automatically.

- **`add-tracing-instrumentation`** — the five-part recipe for a new tracing instrumentation: swappable `AttributeProvider` + `OperationNameResolver`, the blacklist `Voter`, semconv constants over string literals, the decorator-vs-EventSubscriber seam choice (incl. the deferred-span `__destruct` backstop), and the DI wiring across `semconv.php` / feature config / `Configuration.php` / `Extension.php`.
- **`add-metric`** — the metrics conventions, which intentionally differ from tracing: DI-only meter (no static facade), instrument naming, plain-string attributes, separate feature toggle/subscriber.

## Why

These conventions are strong but implicit; they're currently only discoverable by reading several subsystems. Encoding them as committed skills makes them reviewable and reusable.

## Note

`.claude/` is ignored by some contributors' personal global gitignore, so these were force-added. They are tracked normally for all clones and CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)