### PR TITLE
refactor(DI): extract Doctrine wiring into a dedicated compiler pass

### DIFF
--- a/src/DependencyInjection/CompilerPass/DoctrineTracingCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/DoctrineTracingCompilerPass.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Instrumentation\DependencyInjection\CompilerPass;
+
+use Instrumentation\Tracing\Doctrine\Instrumentation\DBAL\Middleware as InstrumentationMiddleware;
+use Instrumentation\Tracing\Doctrine\Propagation\DBAL\Middleware as PropagationMiddleware;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class DoctrineTracingCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('tracing.doctrine.connections') || !$container->hasParameter('doctrine.connections')) {
+            return;
+        }
+
+        /** @var array<string> $connectionsToTrace */
+        $connectionsToTrace = $container->getParameter('tracing.doctrine.connections');
+
+        /** @var array<string,string> $connections */
+        $connections = $container->getParameter('doctrine.connections');
+
+        if (empty($connectionsToTrace)) {
+            $connectionsToTrace = array_keys($connections);
+        }
+
+        foreach ($connectionsToTrace as $connection) {
+            $serviceId = \sprintf('doctrine.dbal.%s_connection', $connection);
+
+            if (!\in_array($serviceId, $connections, true)) {
+                throw new \InvalidArgumentException(\sprintf('No such connection: "%s".', $connection));
+            }
+
+            $configDef = $container->getDefinition(\sprintf('%s.configuration', $serviceId));
+
+            $middlewares = [];
+            foreach ($configDef->getMethodCalls() as $call) {
+                [$method, $arguments] = $call;
+                if ('setMiddlewares' === $method) {
+                    $middlewares = array_merge($middlewares, $arguments[0]);
+                }
+            }
+
+            $addedMiddlewares = [];
+
+            if ($container->getParameter('tracing.doctrine.instrumentation')) {
+                $addedMiddlewares[] = new Reference(InstrumentationMiddleware::class);
+            }
+            if ($container->getParameter('tracing.doctrine.propagation')) {
+                $addedMiddlewares[] = new Reference(PropagationMiddleware::class);
+            }
+
+            $configDef
+                ->removeMethodCall('setMiddlewares')
+                ->addMethodCall('setMiddlewares', [array_merge($middlewares, $addedMiddlewares)]);
+        }
+    }
+}

--- a/src/DependencyInjection/Extension.php
+++ b/src/DependencyInjection/Extension.php
@@ -9,10 +9,9 @@ declare(strict_types=1);
 
 namespace Instrumentation\DependencyInjection;
 
+use Instrumentation\DependencyInjection\CompilerPass\DoctrineTracingCompilerPass;
 use Instrumentation\Tracing\Bridge\TraceUrlGenerator;
 use Instrumentation\Tracing\Bridge\TraceUrlGeneratorInterface;
-use Instrumentation\Tracing\Doctrine\Instrumentation\DBAL\Middleware as InstrumentationMiddleware;
-use Instrumentation\Tracing\Doctrine\Propagation\DBAL\Middleware as PropagationMiddleware;
 use Instrumentation\Tracing\Request\EventListener\AddUserEventSubscriber;
 use OpenTelemetry\SDK\Trace\SpanLimitsBuilder;
 use Symfony\Bundle\MonologBundle\MonologBundle;
@@ -22,7 +21,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension as BaseExtension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\DependencyInjection\Reference;
 
 class Extension extends BaseExtension implements CompilerPassInterface, PrependExtensionInterface
 {
@@ -72,48 +70,7 @@ class Extension extends BaseExtension implements CompilerPassInterface, PrependE
 
     public function process(ContainerBuilder $container): void
     {
-        if ($container->hasParameter('tracing.doctrine.connections') && $container->hasParameter('doctrine.connections')) {
-            /** @var array<string> $connectionsToTrace */
-            $connectionsToTrace = $container->getParameter('tracing.doctrine.connections');
-
-            /** @var array<string,string> $connections */
-            $connections = $container->getParameter('doctrine.connections');
-
-            if (empty($connectionsToTrace)) {
-                $connectionsToTrace = array_keys($connections);
-            }
-
-            foreach ($connectionsToTrace as $connection) {
-                $serviceId = \sprintf('doctrine.dbal.%s_connection', $connection);
-
-                if (!\in_array($serviceId, $connections, true)) {
-                    throw new \InvalidArgumentException(\sprintf('No such connection: "%s".', $connection));
-                }
-
-                $configDef = $container->getDefinition(\sprintf('%s.configuration', $serviceId));
-
-                $middlewares = [];
-                foreach ($configDef->getMethodCalls() as $call) {
-                    [$method, $arguments] = $call;
-                    if ('setMiddlewares' === $method) {
-                        $middlewares = array_merge($middlewares, $arguments[0]);
-                    }
-                }
-
-                $addedMiddlewares = [];
-
-                if ($container->getParameter('tracing.doctrine.instrumentation')) {
-                    $addedMiddlewares[] = new Reference(InstrumentationMiddleware::class);
-                }
-                if ($container->getParameter('tracing.doctrine.propagation')) {
-                    $addedMiddlewares[] = new Reference(PropagationMiddleware::class);
-                }
-
-                $configDef
-                    ->removeMethodCall('setMiddlewares')
-                    ->addMethodCall('setMiddlewares', [array_merge($middlewares, $addedMiddlewares)]);
-            }
-        }
+        (new DoctrineTracingCompilerPass())->process($container);
     }
 
     /**


### PR DESCRIPTION
## What

Extracts the Doctrine connection/middleware wiring from the inline block in `Extension::process()` into a dedicated `DoctrineTracingCompilerPass`. The extension still invokes it from `process()`:

```php
public function process(ContainerBuilder $container): void
{
    (new DoctrineTracingCompilerPass())->process($container);
}
```

## Why

The bundle was inconsistent about where compile-time container manipulation lives:

| Subsystem | Style |
|---|---|
| HttpClient | declarative `->decorate()` in config php (single known service) |
| Doctrine | **inline loop in `Extension::process()`** |
| AI platform | dedicated `*CompilerPass` class |

This standardises the rule: **compile-time wiring that needs container introspection → a dedicated `*CompilerPass` class**, leaving HttpClient's single-service `->decorate()` as the only (justified) declarative case. Doctrine was the lone inline exception.

Behaviour-preserving — pure move, no logic change (the outer `hasParameter` check became an early `return` guard). PHPStan clean at level 8; the new class is unit-test-friendly in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)