### PR TITLE
fix: make telemetry teardown best-effort and lazy

### DIFF
--- a/src/InstrumentationBundle.php
+++ b/src/InstrumentationBundle.php
@@ -37,9 +37,15 @@ class InstrumentationBundle extends Bundle
         }
 
         if ($this->container->has(TracerProviderInterface::class)) {
-            /** @var TracerProviderInterface $tracerProvider */
-            $tracerProvider = $this->container->get(TracerProviderInterface::class);
-            Tracing\Tracing::setProvider($tracerProvider);
+            $container = $this->container;
+            // Hand the facade a lazy closure so the tracer provider (and its OTLP exporter)
+            // is only built when a span is actually created — not on every kernel boot.
+            Tracing\Tracing::setProvider(static function () use ($container): TracerProviderInterface {
+                /** @var TracerProviderInterface $provider */
+                $provider = $container->get(TracerProviderInterface::class);
+
+                return $provider;
+            });
         }
     }
 
@@ -49,18 +55,48 @@ class InstrumentationBundle extends Bundle
             return;
         }
 
+        $container = $this->container;
+
         foreach ([
             TracerProviderInterface::class,
             MeterProviderInterface::class,
             LoggerProviderInterface::class,
         ] as $interface) {
-            if ($this->container->has($interface)) {
-                $provider = $this->container->get($interface);
+            // Only shut down providers that were actually built this process: never
+            // force-instantiate (and lazily build an exporter for) an unused provider.
+            if (!$container->initialized($interface)) {
+                continue;
+            }
+
+            try {
+                $provider = $container->get($interface);
 
                 if (method_exists($provider, 'shutdown')) {
                     $provider->shutdown();
                 }
+            } catch (\Throwable $e) {
+                // A destructor must never throw: teardown is best-effort.
+                $this->logTeardownFailure($interface, $e);
             }
+        }
+    }
+
+    private function logTeardownFailure(string $provider, \Throwable $e): void
+    {
+        try {
+            if (null === $this->container
+                || !$this->container->has(Logging\Logging::class)
+                || !$this->container->initialized(Logging\Logging::class)
+            ) {
+                return;
+            }
+
+            Logging\Logging::getLogger()->error('Failed to shut down telemetry provider during teardown.', [
+                'provider' => $provider,
+                'exception' => $e,
+            ]);
+        } catch (\Throwable) {
+            // Teardown is best-effort: swallow any logging failure so nothing escapes the destructor.
         }
     }
 }

--- a/src/Tracing/Tracing.php
+++ b/src/Tracing/Tracing.php
@@ -20,7 +20,10 @@ final class Tracing
 {
     public const NAME = 'io.opentelemetry.contrib.php.worldia';
 
-    private static TracerProviderInterface|null $tracerProvider = null;
+    /**
+     * @var \Closure():TracerProviderInterface|TracerProviderInterface|null
+     */
+    private static \Closure|TracerProviderInterface|null $tracerProvider = null;
 
     /**
      * @param non-empty-string     $spanName
@@ -41,13 +44,23 @@ final class Tracing
         return new Tracer(self::getProvider()->getTracer($name ?: self::NAME));
     }
 
-    public static function setProvider(TracerProviderInterface $tracerProvider): void
+    /**
+     * @param \Closure():TracerProviderInterface|TracerProviderInterface $tracerProvider
+     */
+    public static function setProvider(\Closure|TracerProviderInterface $tracerProvider): void
     {
         self::$tracerProvider = $tracerProvider;
     }
 
     private static function getProvider(): TracerProviderInterface
     {
-        return self::$tracerProvider ?: new NoopTracerProvider();
+        $provider = self::$tracerProvider;
+
+        if ($provider instanceof \Closure) {
+            $provider = $provider();
+            self::$tracerProvider = $provider;
+        }
+
+        return $provider ?: new NoopTracerProvider();
     }
 }

--- a/tests/Functional/TeardownTest.php
+++ b/tests/Functional/TeardownTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Tests\Instrumentation\Functional;
+
+use Instrumentation\InstrumentationBundle;
+use Instrumentation\Tracing\Tracing;
+use OpenTelemetry\API\Metrics\MeterProviderInterface;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\SDK\Common\Export\InMemoryStorageManager;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Teardown must be best-effort: InstrumentationBundle::__destruct() must never force-instantiate a
+ * telemetry provider that went unused this process (which would lazily build an OTLP exporter for
+ * nothing), and an exception must never escape the destructor. When telemetry *is* used, shutdown
+ * must still flush it.
+ */
+final class TeardownTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        // Force a fresh compile so this genuinely exercises DI compilation.
+        (new Filesystem())->remove(sys_get_temp_dir().'/instrumentation-bundle-tests');
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    public function testTeardownWithoutTelemetryIsInertAndSafe(): void
+    {
+        self::bootKernel();
+
+        // The container the bundle's __destruct actually operates on.
+        $container = self::$kernel->getContainer();
+
+        // boot() must no longer eagerly build the tracer provider (nor any other provider).
+        $this->assertFalse($container->initialized(TracerProviderInterface::class));
+        $this->assertFalse($container->initialized(MeterProviderInterface::class));
+
+        /** @var InstrumentationBundle $bundle */
+        $bundle = self::$kernel->getBundle('InstrumentationBundle');
+
+        // Tearing down a process that emitted no telemetry must not throw ...
+        $bundle->__destruct();
+
+        // ... and must not have force-instantiated the unused providers.
+        $this->assertFalse($container->initialized(TracerProviderInterface::class));
+        $this->assertFalse($container->initialized(MeterProviderInterface::class));
+    }
+
+    public function testRecordedSpanIsFlushedOnTeardown(): void
+    {
+        // The memory exporter appends to this process-global store; isolate from other tests.
+        InMemoryStorageManager::spans()->exchangeArray([]);
+
+        self::bootKernel();
+
+        $container = self::$kernel->getContainer();
+
+        // Recording a span through the facade lazily builds the DI tracer provider.
+        Tracing::trace('teardown-regression-span')->end();
+
+        $this->assertTrue($container->initialized(TracerProviderInterface::class));
+
+        /** @var InstrumentationBundle $bundle */
+        $bundle = self::$kernel->getBundle('InstrumentationBundle');
+        $bundle->__destruct();
+
+        $spans = InMemoryStorageManager::spans();
+        $this->assertCount(1, $spans);
+        $this->assertSame('teardown-regression-span', $spans[0]->getName());
+    }
+}

--- a/tests/InstrumentationBundleTest.php
+++ b/tests/InstrumentationBundleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the worldia/instrumentation-bundle package.
+ * (c) Worldia <developers@worldia.com>
+ */
+
+namespace Tests\Instrumentation;
+
+use Instrumentation\InstrumentationBundle;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+final class InstrumentationBundleTest extends TestCase
+{
+    public function testDestructSwallowsProviderShutdownExceptions(): void
+    {
+        $container = new Container();
+
+        // __destruct() is duck-typed (it only checks method_exists(..., 'shutdown')), so a bare
+        // object whose shutdown() throws is enough to model a provider whose OTLP exporter fails —
+        // e.g. the real "Transport factory not defined for protocol: grpc" that killed a build.
+        $container->set(TracerProviderInterface::class, new class {
+            public function shutdown(): bool
+            {
+                throw new \RuntimeException('Transport factory not defined for protocol: grpc');
+            }
+        });
+
+        $bundle = new InstrumentationBundle();
+        $bundle->setContainer($container);
+
+        // The provider is built (initialized) and its shutdown will throw ...
+        $this->assertTrue($container->initialized(TracerProviderInterface::class));
+
+        // ... but the exception must never escape the destructor.
+        $bundle->__destruct();
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
## Problem

`InstrumentationBundle::__destruct()` tore telemetry down by gating on `$container->has($interface)` — which is `true` whenever the service is merely *defined* — then calling `$container->get($interface)`. That **force-instantiated a provider that was never used** in the process and, via `shutdown()`→`forceFlush()`, **lazily built the OTLP exporter just to shut it down**. Because `boot()` eagerly built the tracer provider to wire the `Tracing` facade, this ran on **every kernel boot**, even for processes that emit no telemetry.

Two failure modes resulted, both on any boot+shutdown that emits no telemetry (`cache:clear`, most CLI commands, image builds, test bootstrap):

1. Useless work: an unused provider + exporter is constructed purely to be torn down.
2. **A destructor that throws.** If the exporter can't be built or the collector is unreachable, the exception escapes `__destruct()` and crashes the host process.

Real-world failure that motivated this: building the production Docker image, `php bin/console cache:clear --env=prod` aborted with `RuntimeException: Transport factory not defined for protocol: grpc` thrown from `__destruct() → TracerProvider::shutdown() → OTLP SpanExporterFactory` (the deployment ships no gRPC transport). No spans were ever recorded — the exporter was built purely to shut it down, then threw and killed the build.

## Fix

- **`boot()`** hands the `Tracing` facade a **lazy closure** instead of an eagerly-built provider, so the tracer provider (and its exporter) is only built when a span is actually created — not on every boot.
- **`__destruct()`** guards on **`Container::initialized()`** instead of `has()` (only shuts down providers actually built this process), and wraps each `get()`+`shutdown()` in `try/catch (\Throwable)` so **an exception can never escape the destructor**. Failures are best-effort logged via the bundle logger when it is available, otherwise swallowed.
- **`Tracing::setProvider()`** now also accepts a `Closure` returning the provider — a backward-compatible widening (the only caller is `boot()`).

When telemetry **is** used, spans/metrics/logs are still flushed on shutdown exactly as before — the provider gets built (and `initialized()` returns `true`) as soon as it is used, whether via the facade or DI injection.

## Tests

- `tests/Functional/TeardownTest.php`
  - `testTeardownWithoutTelemetryIsInertAndSafe` — after a bare kernel boot the tracer/meter providers are **not** `initialized()`, and `__destruct()` neither throws nor force-instantiates them.
  - `testRecordedSpanIsFlushedOnTeardown` — regression: a span recorded through the facade is still flushed to the (in-memory) exporter on shutdown.
- `tests/InstrumentationBundleTest.php`
  - `testDestructSwallowsProviderShutdownExceptions` — a provider whose `shutdown()` throws (modelling the exact `grpc` transport error) does not propagate out of the destructor.

## Verification

- PHPStan (level 8, `src/`): no errors
- php-cs-fixer (`--dry-run`): clean
- PHPUnit: full suite green; 3 new tests pass

## Note

The consuming platform's workaround (pinning `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_PROTOCOL=http/protobuf` so the exporter builds instead of throwing) stays valid. This fix removes the underlying fragility so any misconfiguration/unavailability degrades gracefully instead of crashing the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
